### PR TITLE
refactor: derive finalized sync committee period from finalized header

### DIFF
--- a/src/consensus/light_client.rs
+++ b/src/consensus/light_client.rs
@@ -271,9 +271,9 @@ impl LightClientProcessor {
         current_slot.saturating_sub(head_slot) <= 64
     }
 
-    /// Current sync committee period
+    /// Current sync committee period (derived from finalized header).
     pub(crate) fn current_period(&self) -> u64 {
-        self.sync_committee_tracker.current_period()
+        self.store.finalized_sync_committee_period(&self.chain_spec)
     }
 
     /// Chain specification

--- a/src/types/consensus.rs
+++ b/src/types/consensus.rs
@@ -328,18 +328,19 @@ impl LightClientStore {
         }
     }
 
-    // The following methods are reserved for future force_update implementation
-
-    /// Get the current sync committee period.
-    #[allow(dead_code)]
-    pub fn current_period(&self, spec: &ChainSpec) -> u64 {
+    /// Get the sync committee period derived from the finalized header.
+    ///
+    /// This is the canonical "store period" per consensus-specs.
+    pub(crate) fn finalized_sync_committee_period(&self, spec: &ChainSpec) -> u64 {
         spec.slot_to_sync_committee_period(self.finalized_header.slot)
     }
+
+    // The following methods are reserved for future force_update implementation
 
     /// Get the next sync committee period.
     #[allow(dead_code)]
     pub fn next_period(&self, spec: &ChainSpec) -> u64 {
-        self.current_period(spec) + 1
+        self.finalized_sync_committee_period(spec) + 1
     }
 
     /// Check if we should update the sync committee for the given period.
@@ -449,7 +450,8 @@ mod tests {
 
         let store =
             LightClientStore::new(finalized_header, sync_committee, genesis_validators_root);
-        assert_eq!(store.current_period(&spec), 0); // epoch 31 / 256 = 0
+        // slot 1000 -> epoch 31 -> period 0
+        assert_eq!(store.finalized_sync_committee_period(&spec), 0);
         assert_eq!(store.next_period(&spec), 1);
         assert_eq!(store.genesis_validators_root, genesis_validators_root);
     }


### PR DESCRIPTION
## Goal
Align “store period” with consensus-specs: derive sync committee period from `store.finalized_header.slot` (via `ChainSpec`), not from an attested-driven counter.

## What’s in this PR so far (Commit 1)
- Added `LightClientStore::finalized_sync_committee_period(spec)` (derived from finalized header slot).
- `LightClientProcessor::current_period()` now returns the finalized-derived period.
- Removed `SyncCommitteeTracker::current_period()` getter to avoid semantic confusion (tracker still has internal counter for now); adjusted tracker unit tests accordingly.

## What’s next (Commit 2)
Rotate committees on the *finalized* boundary:
- Trigger rotation only when `finalized_sync_committee_period` advances and `next_sync_committee` is known.
- Keep “learning next committee” from attested headers allowed during the current period (spec-normal).
- Avoid rotating solely because an *attested* header is in period+1.

## Constraints
Please keep this PR reviewable: avoid larger SCTracker/LCStore refactors beyond finalized-derived period + finalized-boundary rotation.