### PR TITLE
test: trim spec test output and remove HashSet tracking

### DIFF
--- a/src/consensus/light_client_spec_tests.rs
+++ b/src/consensus/light_client_spec_tests.rs
@@ -27,7 +27,6 @@ use crate::test_utils::{
     hex_to_root, ForceUpdateStep, ProcessUpdateStep, SpecTestLoader, TestStep,
 };
 use crate::types::consensus::{LightClientBootstrap, LightClientUpdate};
-use std::collections::HashSet;
 
 // ============================================================================
 // Shared Helper Functions
@@ -68,7 +67,6 @@ fn initialize_processor() -> LightClientProcessor {
 
 struct StepResult {
     passed: bool,
-    update_type: &'static str,
 }
 
 fn execute_process_update_step(
@@ -77,121 +75,71 @@ fn execute_process_update_step(
     processor: &mut LightClientProcessor,
     loader: &SpecTestLoader,
 ) -> StepResult {
-    println!("\n📍 Step {}: process_update", step_num);
-    println!("   Update file: {}", step.update);
-    println!("   Current slot: {}", step.current_slot);
-
-    let before_finalized = processor.finalized_header().slot;
-    let before_optimistic = processor.optimistic_header().slot;
-
     let update = match loader.load_update(&step.update) {
         Ok(u) => u,
         Err(e) => {
-            println!("   ❌ FAIL: Failed to load update: {}", e);
-            return StepResult {
-                passed: false,
-                update_type: "Unknown",
-            };
+            println!("  step {}: FAIL - load error: {}", step_num, e);
+            return StepResult { passed: false };
         }
     };
 
     let update_type = detect_update_type(&update);
-    println!("   Update type: {}", update_type);
-    println!("   Attested slot: {}", update.attested_header.slot);
-    println!("   Signature slot: {}", update.signature_slot);
-    if let Some(ref fin) = update.finalized_header {
-        println!("   Finalized slot: {}", fin.slot);
-    }
-    if update.next_sync_committee.is_some() {
-        println!("   Has next sync committee: true");
-    }
+    println!(
+        "  step {}: {} (attested={}, sig={}, current_slot={})",
+        step_num,
+        update_type,
+        update.attested_header.slot,
+        update.signature_slot,
+        step.current_slot,
+    );
 
     match processor.process_update_at_slot(update, step.current_slot) {
-        Ok(state_changed) => {
-            let after_finalized = processor.finalized_header().slot;
-            let after_optimistic = processor.optimistic_header().slot;
-
-            println!("   State changed: {}", state_changed);
-            println!(
-                "   Before: finalized={}, optimistic={}",
-                before_finalized, before_optimistic
-            );
-            println!(
-                "   After:  finalized={}, optimistic={}",
-                after_finalized, after_optimistic
-            );
-
+        Ok(_state_changed) => {
             let mut step_passed = true;
 
             if let Some(ref expected) = step.checks.finalized_header {
-                if after_finalized != expected.slot {
-                    println!(
-                        "   ❌ Finalized slot mismatch! Expected: {}, Actual: {}",
-                        expected.slot, after_finalized
-                    );
-                    step_passed = false;
-                } else {
-                    println!("   ✅ Finalized slot matches: {}", after_finalized);
-                }
-
+                let actual_slot = processor.finalized_header().slot;
                 let actual_root = processor
                     .finalized_header()
                     .hash_tree_root()
-                    .expect("Failed to compute hash_tree_root");
+                    .expect("hash_tree_root");
                 let expected_root =
                     hex_to_root(&expected.beacon_root).expect("Invalid beacon_root");
 
-                if actual_root != expected_root {
-                    println!("   ❌ Finalized beacon_root mismatch!");
+                if actual_slot != expected.slot || actual_root != expected_root {
+                    println!(
+                        "    FAIL finalized: expected slot={} got={}",
+                        expected.slot, actual_slot
+                    );
                     step_passed = false;
-                } else {
-                    println!("   ✅ Finalized beacon_root matches");
                 }
             }
 
             if let Some(ref expected) = step.checks.optimistic_header {
-                if after_optimistic != expected.slot {
-                    println!(
-                        "   ❌ Optimistic slot mismatch! Expected: {}, Actual: {}",
-                        expected.slot, after_optimistic
-                    );
-                    step_passed = false;
-                } else {
-                    println!("   ✅ Optimistic slot matches: {}", after_optimistic);
-                }
-
+                let actual_slot = processor.optimistic_header().slot;
                 let actual_root = processor
                     .optimistic_header()
                     .hash_tree_root()
-                    .expect("Failed to compute hash_tree_root");
+                    .expect("hash_tree_root");
                 let expected_root =
                     hex_to_root(&expected.beacon_root).expect("Invalid beacon_root");
 
-                if actual_root != expected_root {
-                    println!("   ❌ Optimistic beacon_root mismatch!");
+                if actual_slot != expected.slot || actual_root != expected_root {
+                    println!(
+                        "    FAIL optimistic: expected slot={} got={}",
+                        expected.slot, actual_slot
+                    );
                     step_passed = false;
-                } else {
-                    println!("   ✅ Optimistic beacon_root matches");
                 }
-            }
-
-            if step_passed {
-                println!("   ✅ PASS");
-            } else {
-                println!("   ❌ FAIL");
             }
 
             StepResult {
                 passed: step_passed,
-                update_type,
             }
         }
         Err(e) => {
-            println!("   ❌ FAIL: Update processing error: {}", e);
-            StepResult {
-                passed: false,
-                update_type,
-            }
+            println!("    FAIL: process error: {}", e);
+            StepResult { passed: false }
         }
     }
 }
@@ -201,53 +149,19 @@ fn execute_force_update_step(
     step: &ForceUpdateStep,
     processor: &mut LightClientProcessor,
 ) -> bool {
-    println!("\n📍 Step {}: force_update", step_num);
-    println!("   Current slot: {}", step.current_slot);
-
-    let before_finalized = processor.finalized_header().slot;
-    let before_optimistic = processor.optimistic_header().slot;
-
-    // TODO: Implement force_update in LightClientProcessor
-    println!("   ⚠️ force_update not yet implemented");
-
-    let after_finalized = processor.finalized_header().slot;
-    let after_optimistic = processor.optimistic_header().slot;
-
-    println!(
-        "   Before: finalized={}, optimistic={}",
-        before_finalized, before_optimistic
-    );
-    println!(
-        "   After:  finalized={}, optimistic={}",
-        after_finalized, after_optimistic
-    );
+    println!("  step {}: force_update (not implemented)", step_num);
 
     let mut step_passed = true;
 
     if let Some(ref expected) = step.checks.finalized_header {
-        if after_finalized != expected.slot {
-            println!(
-                "   ❌ Finalized slot mismatch! Expected: {}, Actual: {}",
-                expected.slot, after_finalized
-            );
+        if processor.finalized_header().slot != expected.slot {
             step_passed = false;
         }
     }
-
     if let Some(ref expected) = step.checks.optimistic_header {
-        if after_optimistic != expected.slot {
-            println!(
-                "   ❌ Optimistic slot mismatch! Expected: {}, Actual: {}",
-                expected.slot, after_optimistic
-            );
+        if processor.optimistic_header().slot != expected.slot {
             step_passed = false;
         }
-    }
-
-    if step_passed {
-        println!("   ✅ PASS");
-    } else {
-        println!("   ❌ FAIL");
     }
 
     step_passed
@@ -261,30 +175,20 @@ fn execute_force_update_step(
 /// Skips force_update steps (6, 9) and steps that depend on them (7, 8, 10).
 #[test]
 fn test_altair_light_client_sync() {
-    println!("\n🧪 Light Client Sync Spec Test (Happy Path: Steps 1-5)");
-    println!("{}", "=".repeat(70));
-
     let loader = SpecTestLoader::minimal_altair_sync();
     let steps = loader.load_steps().expect("Failed to load steps");
-
-    println!("   Total steps in spec: {}", steps.len());
-    println!("   Running: steps 1-5 only");
-
     let mut processor = initialize_processor();
 
     let mut passed = 0;
     let mut failed = 0;
-    let mut update_types_seen = HashSet::new();
 
-    println!("\n🔄 Executing test steps...");
-    println!("{}", "=".repeat(70));
+    println!("altair light client sync (steps 1-5):");
 
     for (i, step) in steps.iter().enumerate().take(5) {
         match step {
             TestStep::ProcessUpdate { process_update } => {
                 let result =
                     execute_process_update_step(i + 1, process_update, &mut processor, &loader);
-                update_types_seen.insert(result.update_type);
                 if result.passed {
                     passed += 1;
                 } else {
@@ -292,21 +196,13 @@ fn test_altair_light_client_sync() {
                 }
             }
             TestStep::ForceUpdate { .. } => {
-                println!("\n📍 Step {}: force_update (skipped)", i + 1);
+                println!("  step {}: force_update (skipped)", i + 1);
             }
         }
     }
 
-    println!("\n{}", "=".repeat(70));
-    println!("📊 Test Summary (Happy Path)");
-    println!("{}", "=".repeat(70));
-    println!("   Steps executed: {}", passed + failed);
-    println!("   ✅ Passed: {}", passed);
-    println!("   ❌ Failed: {}", failed);
-    println!("   Update types tested: {:?}", update_types_seen);
-
-    assert_eq!(failed, 0, "❌ {} test step(s) failed!", failed);
-    println!("\n🎉 All happy path tests passed!");
+    println!("  result: {}/{} passed", passed, passed + failed);
+    assert_eq!(failed, 0, "{} step(s) failed", failed);
 }
 
 /// Full spec compliance test including force_update steps.
@@ -314,29 +210,20 @@ fn test_altair_light_client_sync() {
 #[test]
 #[ignore = "force_update not yet implemented"]
 fn test_altair_light_client_sync_with_force_update() {
-    println!("\n🧪 Light Client Sync Spec Test (Full)");
-    println!("{}", "=".repeat(70));
-
     let loader = SpecTestLoader::minimal_altair_sync();
     let steps = loader.load_steps().expect("Failed to load steps");
-
-    println!("   Total steps: {}", steps.len());
-
     let mut processor = initialize_processor();
 
     let mut passed = 0;
     let mut failed = 0;
-    let mut update_types_seen = HashSet::new();
 
-    println!("\n🔄 Executing all test steps...");
-    println!("{}", "=".repeat(70));
+    println!("altair light client sync (full, {} steps):", steps.len());
 
     for (i, step) in steps.iter().enumerate() {
         match step {
             TestStep::ProcessUpdate { process_update } => {
                 let result =
                     execute_process_update_step(i + 1, process_update, &mut processor, &loader);
-                update_types_seen.insert(result.update_type);
                 if result.passed {
                     passed += 1;
                 } else {
@@ -353,14 +240,6 @@ fn test_altair_light_client_sync_with_force_update() {
         }
     }
 
-    println!("\n{}", "=".repeat(70));
-    println!("📊 Test Summary (Full Spec)");
-    println!("{}", "=".repeat(70));
-    println!("   Total steps: {}", passed + failed);
-    println!("   ✅ Passed: {}", passed);
-    println!("   ❌ Failed: {}", failed);
-    println!("   Update types tested: {:?}", update_types_seen);
-
-    assert_eq!(failed, 0, "❌ {} test step(s) failed!", failed);
-    println!("\n🎉 All spec tests passed!");
+    println!("  result: {}/{} passed", passed, passed + failed);
+    assert_eq!(failed, 0, "{} step(s) failed", failed);
 }


### PR DESCRIPTION
Remove emoji banners, separator lines, and update_types_seen HashSet. Keep one diagnostic line per step and failure details.