### PR TITLE
feat: introduce fork-aware LightClientHeader enum

### DIFF
--- a/src/consensus/light_client.rs
+++ b/src/consensus/light_client.rs
@@ -3,7 +3,7 @@ use crate::consensus::merkle::{verify_bootstrap_sync_committee, verify_finality_
 use crate::consensus::sync_committee;
 use crate::error::{Error, Result};
 use crate::types::consensus::{
-    BeaconBlockHeader, LightClientStore, LightClientUpdate, SyncCommittee,
+    BeaconBlockHeader, LightClientHeader, LightClientStore, LightClientUpdate, SyncCommittee,
 };
 use crate::types::primitives::Root;
 use crate::types::primitives::Slot;
@@ -46,7 +46,7 @@ impl LightClientProcessor {
         )?;
 
         let store = LightClientStore::new(
-            trusted_header,
+            LightClientHeader::altair(trusted_header),
             current_sync_committee,
             genesis_validators_root,
         );
@@ -110,10 +110,10 @@ impl LightClientProcessor {
         let has_sync_committee = update.has_sync_committee_update();
         let is_slot_acceptable = if has_sync_committee {
             // Allow equal slots if update contains sync committee (useful for bootstrapping)
-            update.attested_header.slot >= self.store.finalized_header.slot
+            update.attested_header.slot() >= self.store.finalized_header.slot()
         } else {
             // Regular updates must be strictly newer
-            update.attested_header.slot > self.store.finalized_header.slot
+            update.attested_header.slot() > self.store.finalized_header.slot()
         };
 
         if !is_slot_acceptable {
@@ -132,7 +132,7 @@ impl LightClientProcessor {
         // Look up the committee for the signature slot from the store
         let committee = sync_committee::committee_for_slot(
             update.signature_slot,
-            self.store.finalized_header.slot,
+            self.store.finalized_header.slot(),
             &self.store.current_sync_committee,
             self.store.next_sync_committee.as_ref(),
             &self.chain_spec,
@@ -166,17 +166,17 @@ impl LightClientProcessor {
 
         // Update finalized header (verify finality proof first)
         if let Some(ref finalized_header) = update.finalized_header {
-            if finalized_header.slot > self.store.finalized_header.slot {
+            if finalized_header.slot() > self.store.finalized_header.slot() {
                 let finalized_header_root = finalized_header.hash_tree_root()?;
                 verify_finality_branch(
                     &finalized_header_root,
                     &update.finality_branch,
-                    update.attested_header.slot,
-                    &update.attested_header.state_root,
+                    update.attested_header.slot(),
+                    update.attested_header.state_root(),
                     &self.chain_spec,
                 )?;
 
-                self.store.finalized_header = finalized_header.clone(); // <- why clone here?  seems much more intuitive to consume the update's finalized header no?
+                self.store.finalized_header = finalized_header.clone();
                 state_changed = true;
             }
         }
@@ -186,7 +186,7 @@ impl LightClientProcessor {
         if let Some(ref finalized_header) = update.finalized_header {
             let update_finalized_period = self
                 .chain_spec
-                .slot_to_sync_committee_period(finalized_header.slot);
+                .slot_to_sync_committee_period(finalized_header.slot());
 
             if update_finalized_period == store_period + 1
                 && self.store.next_sync_committee.is_some()
@@ -219,7 +219,7 @@ impl LightClientProcessor {
         }
 
         // Update optimistic header if this is better
-        if update.attested_header.slot > self.store.optimistic_header.slot {
+        if update.attested_header.slot() > self.store.optimistic_header.slot() {
             self.store.optimistic_header = update.attested_header.clone();
             state_changed = true;
         }
@@ -234,14 +234,14 @@ impl LightClientProcessor {
         Ok(state_changed)
     }
 
-    /// Current finalized header
+    /// Current finalized header (beacon block header, regardless of fork).
     pub(crate) fn finalized_header(&self) -> &BeaconBlockHeader {
-        &self.store.finalized_header
+        self.store.finalized_header.beacon()
     }
 
-    /// Current optimistic header (may be ahead of finalized)
+    /// Current optimistic header (may be ahead of finalized).
     pub(crate) fn optimistic_header(&self) -> &BeaconBlockHeader {
-        &self.store.optimistic_header
+        self.store.optimistic_header.beacon()
     }
 
     /// Current sync committee
@@ -289,11 +289,11 @@ mod tests {
     fn test_light_client_processor_creation() {
         let bootstrap = load_bootstrap_fixture();
         let chain_spec = crate::config::ChainSpec::minimal();
-        let expected_slot = bootstrap.header.slot;
+        let expected_slot = bootstrap.header.slot();
 
         let processor = LightClientProcessor::new(
             chain_spec,
-            bootstrap.header,
+            bootstrap.header.beacon().clone(),
             bootstrap.current_sync_committee,
             &bootstrap.current_sync_committee_branch,
             bootstrap.genesis_validators_root,
@@ -313,7 +313,7 @@ mod tests {
 
         let result = LightClientProcessor::new(
             chain_spec,
-            bootstrap.header,
+            bootstrap.header.beacon().clone(),
             bootstrap.current_sync_committee,
             &empty_branch,
             bootstrap.genesis_validators_root,
@@ -326,11 +326,11 @@ mod tests {
     fn test_light_client_update_validation() {
         let bootstrap = load_bootstrap_fixture();
         let chain_spec = crate::config::ChainSpec::minimal();
-        let bootstrap_slot = bootstrap.header.slot;
+        let bootstrap_slot = bootstrap.header.slot();
 
         let processor = LightClientProcessor::new(
             chain_spec,
-            bootstrap.header,
+            bootstrap.header.beacon().clone(),
             bootstrap.current_sync_committee,
             &bootstrap.current_sync_committee_branch,
             bootstrap.genesis_validators_root,
@@ -373,11 +373,11 @@ mod tests {
     fn test_store_period_correct_after_rotation() {
         let bootstrap = load_bootstrap_fixture();
         let chain_spec = crate::config::ChainSpec::minimal();
-        let bootstrap_slot = bootstrap.header.slot;
+        let bootstrap_slot = bootstrap.header.slot();
 
         let mut processor = LightClientProcessor::new(
             chain_spec.clone(),
-            bootstrap.header,
+            bootstrap.header.beacon().clone(),
             bootstrap.current_sync_committee.clone(),
             &bootstrap.current_sync_committee_branch,
             bootstrap.genesis_validators_root,
@@ -413,7 +413,7 @@ mod tests {
                 .take()
                 .expect("checked is_some");
             // Advance finalized header to match (as apply_light_client_update does)
-            processor.store.finalized_header = finalized;
+            processor.store.finalized_header = LightClientHeader::altair(finalized);
         }
 
         // Assertions: store state is correct after rotation

--- a/src/consensus/light_client.rs
+++ b/src/consensus/light_client.rs
@@ -31,7 +31,7 @@ impl LightClientProcessor {
     /// Returns an error if the sync committee branch proof fails verification.
     pub(crate) fn new(
         chain_spec: ChainSpec,
-        trusted_header: BeaconBlockHeader,
+        trusted_header: LightClientHeader,
         current_sync_committee: SyncCommittee,
         current_sync_committee_branch: &[Root],
         genesis_validators_root: Root,
@@ -40,13 +40,13 @@ impl LightClientProcessor {
         verify_bootstrap_sync_committee(
             &current_sync_committee,
             current_sync_committee_branch,
-            trusted_header.slot,
-            &trusted_header.state_root,
+            trusted_header.slot(),
+            trusted_header.state_root(),
             &chain_spec,
         )?;
 
         let store = LightClientStore::new(
-            LightClientHeader::altair(trusted_header),
+            trusted_header,
             current_sync_committee,
             genesis_validators_root,
         );
@@ -293,7 +293,7 @@ mod tests {
 
         let processor = LightClientProcessor::new(
             chain_spec,
-            bootstrap.header.beacon().clone(),
+            bootstrap.header.clone(),
             bootstrap.current_sync_committee,
             &bootstrap.current_sync_committee_branch,
             bootstrap.genesis_validators_root,
@@ -313,7 +313,7 @@ mod tests {
 
         let result = LightClientProcessor::new(
             chain_spec,
-            bootstrap.header.beacon().clone(),
+            bootstrap.header.clone(),
             bootstrap.current_sync_committee,
             &empty_branch,
             bootstrap.genesis_validators_root,
@@ -330,7 +330,7 @@ mod tests {
 
         let processor = LightClientProcessor::new(
             chain_spec,
-            bootstrap.header.beacon().clone(),
+            bootstrap.header.clone(),
             bootstrap.current_sync_committee,
             &bootstrap.current_sync_committee_branch,
             bootstrap.genesis_validators_root,
@@ -377,7 +377,7 @@ mod tests {
 
         let mut processor = LightClientProcessor::new(
             chain_spec.clone(),
-            bootstrap.header.beacon().clone(),
+            bootstrap.header.clone(),
             bootstrap.current_sync_committee.clone(),
             &bootstrap.current_sync_committee_branch,
             bootstrap.genesis_validators_root,

--- a/src/consensus/light_client_spec_tests.rs
+++ b/src/consensus/light_client_spec_tests.rs
@@ -57,7 +57,7 @@ fn initialize_processor() -> LightClientProcessor {
 
     LightClientProcessor::new(
         chain_spec,
-        bootstrap.header,
+        bootstrap.header.beacon().clone(),
         bootstrap.current_sync_committee,
         &bootstrap.current_sync_committee_branch,
         bootstrap.genesis_validators_root,
@@ -88,7 +88,7 @@ fn execute_process_update_step(
         "  step {}: {} (attested={}, sig={}, current_slot={})",
         step_num,
         update_type,
-        update.attested_header.slot,
+        update.attested_header.slot(),
         update.signature_slot,
         step.current_slot,
     );

--- a/src/consensus/light_client_spec_tests.rs
+++ b/src/consensus/light_client_spec_tests.rs
@@ -57,7 +57,7 @@ fn initialize_processor() -> LightClientProcessor {
 
     LightClientProcessor::new(
         chain_spec,
-        bootstrap.header.beacon().clone(),
+        bootstrap.header.clone(),
         bootstrap.current_sync_committee,
         &bootstrap.current_sync_committee_branch,
         bootstrap.genesis_validators_root,

--- a/src/consensus/sync_committee.rs
+++ b/src/consensus/sync_committee.rs
@@ -80,7 +80,7 @@ pub(crate) fn learn_next_sync_committee_from_update(
         return Ok(None);
     }
 
-    let update_period = chain_spec.slot_to_sync_committee_period(update.attested_header.slot);
+    let update_period = chain_spec.slot_to_sync_committee_period(update.attested_header.slot());
     let attested_next_committee = update.next_sync_committee.as_ref().unwrap();
 
     // Defensive invariant: only learn `next_sync_committee` when
@@ -98,8 +98,8 @@ pub(crate) fn learn_next_sync_committee_from_update(
     verify_next_sync_committee(
         attested_next_committee,
         &update.next_sync_committee_branch,
-        update.attested_header.slot,
-        &update.attested_header.state_root,
+        update.attested_header.slot(),
+        update.attested_header.state_root(),
         chain_spec,
     )?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,8 @@ pub use crate::error::{Error, Result};
 pub use crate::light_client::{LightClient, UpdateOutcome};
 pub use crate::types::{
     consensus::{
-        BeaconBlockHeader, LightClientBootstrap, LightClientUpdate, SyncAggregate, SyncCommittee,
+        BeaconBlockHeader, LightClientBootstrap, LightClientHeader, LightClientUpdate,
+        SyncAggregate, SyncCommittee,
     },
     primitives::{Root, Slot},
 };
@@ -36,7 +37,10 @@ pub mod prelude {
     pub use crate::error::{Error, Result};
     pub use crate::light_client::{LightClient, UpdateOutcome};
     pub use crate::types::{
-        consensus::{BeaconBlockHeader, LightClientBootstrap, LightClientUpdate, SyncCommittee},
+        consensus::{
+            BeaconBlockHeader, LightClientBootstrap, LightClientHeader, LightClientUpdate,
+            SyncCommittee,
+        },
         primitives::{Root, Slot},
     };
 }

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -218,7 +218,7 @@ impl LightClient {
     pub fn new(chain_spec: ChainSpec, bootstrap: LightClientBootstrap) -> Result<Self> {
         let inner = LightClientProcessor::new(
             chain_spec,
-            bootstrap.header.beacon().clone(),
+            bootstrap.header,
             bootstrap.current_sync_committee,
             &bootstrap.current_sync_committee_branch,
             bootstrap.genesis_validators_root,

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -218,7 +218,7 @@ impl LightClient {
     pub fn new(chain_spec: ChainSpec, bootstrap: LightClientBootstrap) -> Result<Self> {
         let inner = LightClientProcessor::new(
             chain_spec,
-            bootstrap.header,
+            bootstrap.header.beacon().clone(),
             bootstrap.current_sync_committee,
             &bootstrap.current_sync_committee_branch,
             bootstrap.genesis_validators_root,
@@ -502,7 +502,7 @@ mod tests {
     fn test_light_client_creation() {
         let bootstrap = load_bootstrap_fixture();
         let chain_spec = ChainSpec::minimal();
-        let expected_slot = bootstrap.header.slot;
+        let expected_slot = bootstrap.header.slot();
 
         let client = LightClient::new(chain_spec, bootstrap).expect("should create light client");
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -13,7 +13,8 @@
 //! ```
 
 use crate::types::consensus::{
-    BeaconBlockHeader, LightClientBootstrap, LightClientUpdate, SyncAggregate, SyncCommittee,
+    BeaconBlockHeader, LightClientBootstrap, LightClientHeader as PubLightClientHeader,
+    LightClientUpdate, SyncAggregate, SyncCommittee,
 };
 use crate::types::primitives::Root;
 use ssz_rs::prelude::*;
@@ -155,8 +156,12 @@ impl RawLightClientUpdate {
             .collect();
 
         Ok(LightClientUpdate {
-            attested_header: self.attested_header.beacon.into_beacon_block_header(),
-            finalized_header: Some(self.finalized_header.beacon.into_beacon_block_header()),
+            attested_header: PubLightClientHeader::altair(
+                self.attested_header.beacon.into_beacon_block_header(),
+            ),
+            finalized_header: Some(PubLightClientHeader::altair(
+                self.finalized_header.beacon.into_beacon_block_header(),
+            )),
             finality_branch,
             next_sync_committee: if has_sync_committee {
                 Some(sync_committee)

--- a/src/types/consensus.rs
+++ b/src/types/consensus.rs
@@ -47,6 +47,88 @@ impl BeaconBlockHeader {
     }
 }
 
+// =============================================================================
+// LightClientHeader (fork-aware)
+// =============================================================================
+
+/// Fork-aware light client header.
+///
+/// Each consensus fork defines its own `LightClientHeader` shape.
+/// In Altair and Bellatrix the header contains only a `BeaconBlockHeader`.
+/// Later forks (Capella onward) add execution payload header fields;
+/// those variants will be added here as the library gains support.
+///
+/// Verification logic accesses the inner `BeaconBlockHeader` through
+/// [`beacon()`](Self::beacon), keeping the pipeline fork-agnostic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LightClientHeader {
+    Altair(AltairLightClientHeader),
+    Bellatrix(BellatrixLightClientHeader),
+    // *** Future variants (require execution payload header types): ***
+    // Capella(CapellaLightClientHeader),
+    // Deneb(DenebLightClientHeader),
+    // Electra(ElectraLightClientHeader),
+    // Fulu(FuluLightClientHeader),
+}
+
+/// Altair light client header — beacon header only.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AltairLightClientHeader {
+    pub beacon: BeaconBlockHeader,
+}
+
+/// Bellatrix light client header — same shape as Altair.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BellatrixLightClientHeader {
+    pub beacon: BeaconBlockHeader,
+}
+
+impl LightClientHeader {
+    /// Wrap a `BeaconBlockHeader` as an Altair-era header.
+    pub fn altair(beacon: BeaconBlockHeader) -> Self {
+        Self::Altair(AltairLightClientHeader { beacon })
+    }
+
+    /// Wrap a `BeaconBlockHeader` as a Bellatrix-era header.
+    #[allow(dead_code)]
+    pub fn bellatrix(beacon: BeaconBlockHeader) -> Self {
+        Self::Bellatrix(BellatrixLightClientHeader { beacon })
+    }
+
+    /// The inner `BeaconBlockHeader` (available for all forks).
+    pub fn beacon(&self) -> &BeaconBlockHeader {
+        match self {
+            Self::Altair(h) => &h.beacon,
+            Self::Bellatrix(h) => &h.beacon,
+        }
+    }
+
+    /// The header's slot.
+    pub fn slot(&self) -> Slot {
+        self.beacon().slot
+    }
+
+    /// The header's state root.
+    pub fn state_root(&self) -> &Root {
+        &self.beacon().state_root
+    }
+
+    /// Compute the hash tree root of this header.
+    ///
+    /// For Altair/Bellatrix this is `hash_tree_root(beacon)`.
+    /// Later forks will hash the full container (beacon + execution).
+    pub fn hash_tree_root(&self) -> Result<Root> {
+        match self {
+            Self::Altair(h) => h.beacon.hash_tree_root(),
+            Self::Bellatrix(h) => h.beacon.hash_tree_root(),
+        }
+    }
+}
+
+// =============================================================================
+// SyncCommittee
+// =============================================================================
+
 /// Sync committee with 512 validators
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SyncCommittee {
@@ -147,17 +229,18 @@ impl SyncAggregate {
     }
 }
 
-/// Light client update containing all data needed for verification
-/// Note: SSZ deserialization requires special handling for next_sync_committee due to fixed arrays
+/// Light client update containing all data needed for verification.
+///
+/// Headers are fork-aware [`LightClientHeader`] values.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LightClientUpdate {
-    /// The beacon block header being attested to
-    pub attested_header: BeaconBlockHeader,
-    /// The finalized beacon block header
-    pub finalized_header: Option<BeaconBlockHeader>,
+    /// The header being attested to (fork-aware).
+    pub attested_header: LightClientHeader,
+    /// The finalized header (fork-aware), if present.
+    pub finalized_header: Option<LightClientHeader>,
     /// Merkle proof for finalized header
     pub finality_branch: Vec<Root>,
-    /// Current sync committee (if committee changes)
+    /// Next sync committee (if committee changes)
     pub next_sync_committee: Option<SyncCommittee>,
     /// Merkle proof for next sync committee
     pub next_sync_committee_branch: Vec<Root>,
@@ -168,13 +251,14 @@ pub struct LightClientUpdate {
 }
 
 impl LightClientUpdate {
+    /// Create a new update wrapping a `BeaconBlockHeader` as Altair.
     pub fn new(
         attested_header: BeaconBlockHeader,
         sync_aggregate: SyncAggregate,
         signature_slot: Slot,
     ) -> Self {
         Self {
-            attested_header,
+            attested_header: LightClientHeader::altair(attested_header),
             finalized_header: None,
             finality_branch: Vec::new(),
             next_sync_committee: None,
@@ -189,7 +273,7 @@ impl LightClientUpdate {
         finalized_header: BeaconBlockHeader,
         finality_branch: Vec<Root>,
     ) -> Self {
-        self.finalized_header = Some(finalized_header);
+        self.finalized_header = Some(LightClientHeader::altair(finalized_header));
         self.finality_branch = finality_branch;
         self
     }
@@ -209,18 +293,13 @@ impl LightClientUpdate {
     /// Enforces:
     /// - `signature_slot > attested_header.slot`
     /// - supermajority participation
-    ///
-    /// Note: The spec also requires `signature_slot <= current_slot`, but that check
-    /// requires wall-clock context and is done in the processor's validation.
     pub fn validate_basic(&self, sync_committee: &SyncCommittee) -> Result<()> {
-        // Signature slot should be after attested header slot
-        if self.signature_slot <= self.attested_header.slot {
+        if self.signature_slot <= self.attested_header.slot() {
             return Err(Error::InvalidInput(
                 "Signature slot must be after attested header slot".to_string(),
             ));
         }
 
-        // Must have supermajority participation (checks against actual committee size)
         if !self.sync_aggregate.has_supermajority(sync_committee) {
             return Err(Error::InvalidInput(
                 "Insufficient sync committee participation".to_string(),
@@ -242,7 +321,7 @@ impl LightClientUpdate {
 
     /// Get the period of the attested header.
     pub fn attested_period(&self, spec: &ChainSpec) -> u64 {
-        spec.slot_to_sync_committee_period(self.attested_header.slot)
+        spec.slot_to_sync_committee_period(self.attested_header.slot())
     }
 
     /// Get the period of the signature slot.
@@ -254,7 +333,7 @@ impl LightClientUpdate {
 /// Bootstrap data for initializing a light client.
 ///
 /// This is the trusted anchor from which light client sync begins. It contains:
-/// - A trusted beacon block header (typically a finalized checkpoint)
+/// - A trusted light client header (fork-aware, typically a finalized checkpoint)
 /// - The sync committee active at that header's slot
 /// - A merkle proof that the sync committee is embedded in the header's state root
 /// - The genesis validators root for the chain (used in signature domain computation)
@@ -262,8 +341,8 @@ impl LightClientUpdate {
 /// Corresponds to the `LightClientBootstrap` object in the Ethereum consensus specs.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LightClientBootstrap {
-    /// The trusted beacon block header (checkpoint header).
-    pub header: BeaconBlockHeader,
+    /// The trusted header (fork-aware).
+    pub header: LightClientHeader,
     /// The current sync committee at the header's slot.
     pub current_sync_committee: SyncCommittee,
     /// Merkle branch proving `current_sync_committee` is in `header.state_root`.
@@ -274,7 +353,7 @@ pub struct LightClientBootstrap {
 }
 
 impl LightClientBootstrap {
-    /// Create a new bootstrap package.
+    /// Create a new bootstrap package from a `BeaconBlockHeader` (Altair).
     pub fn new(
         header: BeaconBlockHeader,
         current_sync_committee: SyncCommittee,
@@ -282,7 +361,7 @@ impl LightClientBootstrap {
         genesis_validators_root: Root,
     ) -> Self {
         Self {
-            header,
+            header: LightClientHeader::altair(header),
             current_sync_committee,
             current_sync_committee_branch,
             genesis_validators_root,
@@ -294,16 +373,17 @@ impl LightClientBootstrap {
 ///
 /// This is the persistent state that a light client maintains across updates.
 /// It includes the trusted headers, sync committees, and chain identity.
+/// Headers are fork-aware [`LightClientHeader`] values.
 #[derive(Debug, Clone)]
 pub(crate) struct LightClientStore {
-    /// Best finalized header we've seen
-    pub finalized_header: BeaconBlockHeader,
+    /// Best finalized header we've seen (fork-aware).
+    pub finalized_header: LightClientHeader,
     /// Current sync committee
     pub current_sync_committee: SyncCommittee,
     /// Next sync committee (if known)
     pub next_sync_committee: Option<SyncCommittee>,
-    /// Optimistic header (may not be finalized)
-    pub optimistic_header: BeaconBlockHeader,
+    /// Optimistic header (may not be finalized, fork-aware).
+    pub optimistic_header: LightClientHeader,
     /// Genesis validators root (chain identity for signature domains)
     pub genesis_validators_root: Root,
     /// Previous max active participants (used by force_update - not yet implemented)
@@ -315,7 +395,7 @@ pub(crate) struct LightClientStore {
 
 impl LightClientStore {
     pub fn new(
-        finalized_header: BeaconBlockHeader,
+        finalized_header: LightClientHeader,
         current_sync_committee: SyncCommittee,
         genesis_validators_root: Root,
     ) -> Self {
@@ -334,7 +414,7 @@ impl LightClientStore {
     ///
     /// This is the canonical "store period" per consensus-specs.
     pub(crate) fn finalized_sync_committee_period(&self, spec: &ChainSpec) -> u64 {
-        spec.slot_to_sync_committee_period(self.finalized_header.slot)
+        spec.slot_to_sync_committee_period(self.finalized_header.slot())
     }
 
     // The following methods are reserved for future force_update implementation
@@ -421,8 +501,11 @@ mod tests {
         let sync_committee = create_test_sync_committee();
         let genesis_validators_root = [0u8; 32];
 
-        let store =
-            LightClientStore::new(finalized_header, sync_committee, genesis_validators_root);
+        let store = LightClientStore::new(
+            LightClientHeader::altair(finalized_header),
+            sync_committee,
+            genesis_validators_root,
+        );
         // slot 1000 -> epoch 31 -> period 0
         assert_eq!(store.finalized_sync_committee_period(&spec), 0);
         assert_eq!(store.next_period(&spec), 1);


### PR DESCRIPTION
Add explicit per-fork light client header types (Altair, Bellatrix) as the structural foundation for multi-fork verification support.

- LightClientHeader enum with Altair/Bellatrix variants
- LightClientUpdate, LightClientBootstrap, and LightClientStore now use LightClientHeader instead of raw BeaconBlockHeader
- Accessor methods (.beacon(), .slot(), .state_root(), .hash_tree_root()) keep verification logic fork-agnostic
- Public API unchanged: getters still return &BeaconBlockHeader
- All existing Altair tests pass unchanged