### PR TITLE
refactor: remove redundant public type alias modules

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,17 +1,2 @@
-// Domain-specific type modules
 pub mod consensus;
 pub mod primitives;
-
-/// Curated primitive types used throughout the light client (CL-focused).
-pub mod primitives_types {
-    pub use crate::types::primitives::{
-        BLSPublicKey, BLSSignature, Bytes, Domain, Epoch, ForkVersion, Root, Slot, ValidatorIndex,
-    };
-}
-
-/// Consensus layer types (Beacon chain)
-pub mod consensus_types {
-    pub use crate::types::consensus::{
-        BeaconBlockHeader, LightClientUpdate, SyncAggregate, SyncCommittee,
-    };
-}


### PR DESCRIPTION
Drop types::primitives_types and types::consensus_types, which duplicated the crate-root re-exports and the types::{primitives,consensus} module paths and were unused across src, tests, and examples. This keeps the canonical import model simple: crate-root named imports, the prelude, and the types::* module paths.