### PR TITLE
test: cover public LightClient API across Altair/Bellatrix/Capella

### DIFF
--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -524,10 +524,7 @@ pub struct SpecTestLoader {
 }
 
 impl SpecTestLoader {
-    /// Create a loader for the minimal/altair sync test.
-    ///
-    /// Looks for fixtures at `tests/fixtures/minimal/altair/light_client/sync/light_client_sync`
-    /// relative to `CARGO_MANIFEST_DIR`.
+    /// Loader for the minimal Altair light-client sync fixtures.
     pub fn minimal_altair_sync() -> Self {
         let test_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("tests/fixtures/minimal/altair/light_client/sync/light_client_sync");
@@ -537,11 +534,7 @@ impl SpecTestLoader {
         }
     }
 
-    /// Create a loader for the minimal/bellatrix sync test.
-    ///
-    /// Uses real Bellatrix spec fixtures (same `LightClientHeader` shape as
-    /// Altair — no execution payload header yet — but independently generated
-    /// BLS signatures, merkle proofs, and header data).
+    /// Loader for the minimal Bellatrix light-client sync fixtures.
     pub fn minimal_bellatrix_sync() -> Self {
         let test_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("tests/fixtures/minimal/bellatrix/light_client/sync/light_client_sync");
@@ -551,9 +544,7 @@ impl SpecTestLoader {
         }
     }
 
-    /// Create a loader for the minimal/capella sync test.
-    ///
-    /// Uses real Capella spec fixtures with execution payload headers.
+    /// Loader for the minimal Capella light-client sync fixtures.
     pub fn minimal_capella_sync() -> Self {
         let test_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("tests/fixtures/minimal/capella/light_client/sync/light_client_sync");
@@ -563,7 +554,6 @@ impl SpecTestLoader {
         }
     }
 
-    /// Create a loader for a custom test directory with an explicit fork tag.
     pub fn from_path(path: impl Into<PathBuf>, fork: TestFork) -> Self {
         Self {
             test_dir: path.into(),
@@ -571,12 +561,10 @@ impl SpecTestLoader {
         }
     }
 
-    /// Return a `ChainSpec` matching this loader's fork.
     pub fn chain_spec(&self) -> crate::config::ChainSpec {
         self.fork.chain_spec()
     }
 
-    /// Load bootstrap data from the test fixtures.
     pub fn load_bootstrap(&self) -> Result<BootstrapData, Box<dyn std::error::Error>> {
         let meta = self.load_meta()?;
         let genesis_validators_root = hex_to_root(&meta.genesis_validators_root)?;
@@ -613,9 +601,7 @@ impl SpecTestLoader {
         }
     }
 
-    /// Load a specific update by name.
-    ///
-    /// The name should not include the `.ssz_snappy` extension.
+    /// `name` must not include the `.ssz_snappy` extension.
     pub fn load_update(&self, name: &str) -> Result<LightClientUpdate, Box<dyn std::error::Error>> {
         let update_path = self.test_dir.join(format!("{}.ssz_snappy", name));
 
@@ -632,7 +618,6 @@ impl SpecTestLoader {
         }
     }
 
-    /// Load test metadata from meta.yaml.
     pub fn load_meta(&self) -> Result<TestMeta, Box<dyn std::error::Error>> {
         let meta_path = self.test_dir.join("meta.yaml");
         let meta_contents = fs::read_to_string(&meta_path)?;
@@ -640,7 +625,6 @@ impl SpecTestLoader {
         Ok(meta)
     }
 
-    /// Load test steps from steps.yaml.
     pub fn load_steps(&self) -> Result<Vec<TestStep>, Box<dyn std::error::Error>> {
         let steps_path = self.test_dir.join("steps.yaml");
         let steps_contents = fs::read_to_string(&steps_path)?;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -32,8 +32,7 @@ pub enum TestFork {
 }
 
 impl TestFork {
-    /// Wrap a `BeaconBlockHeader` into the corresponding `LightClientHeader` variant.
-    /// Only valid for Altair/Bellatrix (no execution payload).
+    /// Only valid for Altair/Bellatrix; Capella headers carry an execution payload (panics).
     fn wrap_header(&self, beacon: BeaconBlockHeader) -> PubLightClientHeader {
         match self {
             TestFork::Altair => PubLightClientHeader::altair(beacon),
@@ -417,7 +416,6 @@ impl RawLightClientUpdate {
 /// Metadata from a spec test's meta.yaml file.
 #[derive(Debug, serde::Deserialize)]
 pub struct TestMeta {
-    /// Genesis validators root as hex string (0x-prefixed).
     pub genesis_validators_root: String,
     #[allow(dead_code)]
     trusted_block_root: String,
@@ -427,23 +425,17 @@ pub struct TestMeta {
     store_fork_digest: String,
 }
 
-/// Expected state after a test step.
 #[derive(Debug, serde::Deserialize)]
 pub struct StateChecks {
-    /// Expected finalized header state.
     pub finalized_header: Option<HeaderCheck>,
-    /// Expected optimistic header state.
     pub optimistic_header: Option<HeaderCheck>,
 }
 
-/// Expected header values.
 #[derive(Debug, serde::Deserialize)]
 pub struct HeaderCheck {
-    /// Expected slot.
     pub slot: u64,
-    /// Expected beacon block root as hex string.
     pub beacon_root: String,
-    /// Expected execution payload root as hex string (Capella+, absent for Altair/Bellatrix).
+    /// Present only for Capella+ (absent for Altair/Bellatrix).
     #[serde(default)]
     pub execution_root: Option<String>,
 }
@@ -452,37 +444,28 @@ pub struct HeaderCheck {
 #[derive(Debug, serde::Deserialize)]
 #[serde(untagged)]
 pub enum TestStep {
-    /// Process a light client update.
     ProcessUpdate {
-        /// The process_update step data.
         process_update: ProcessUpdateStep,
     },
     /// Force update (safety timeout mechanism).
     ForceUpdate {
-        /// The force_update step data.
         force_update: ForceUpdateStep,
     },
 }
 
-/// Data for a process_update test step.
 #[derive(Debug, serde::Deserialize)]
 pub struct ProcessUpdateStep {
     #[allow(dead_code)]
     update_fork_digest: String,
     /// Update file name (without .ssz_snappy extension).
     pub update: String,
-    /// Current slot when processing the update.
     pub current_slot: u64,
-    /// Expected state after processing.
     pub checks: StateChecks,
 }
 
-/// Data for a force_update test step.
 #[derive(Debug, serde::Deserialize)]
 pub struct ForceUpdateStep {
-    /// Current slot when forcing update.
     pub current_slot: u64,
-    /// Expected state after forcing.
     pub checks: StateChecks,
 }
 
@@ -490,21 +473,15 @@ pub struct ForceUpdateStep {
 // Public API
 // ============================================================================
 
-/// Bootstrap data loaded from spec test fixtures.
 #[derive(Debug, Clone)]
 pub struct BootstrapData {
-    /// The trusted header (fork-aware).
     pub header: PubLightClientHeader,
-    /// The current sync committee.
     pub sync_committee: SyncCommittee,
-    /// Merkle branch proving sync committee in state.
     pub branch: Vec<Root>,
-    /// Genesis validators root for signature domain.
     pub genesis_validators_root: Root,
 }
 
 impl BootstrapData {
-    /// Convert to the public [`LightClientBootstrap`] type.
     pub fn into_bootstrap(self) -> LightClientBootstrap {
         LightClientBootstrap::from_header(
             self.header,

--- a/tests/light_client_sync.rs
+++ b/tests/light_client_sync.rs
@@ -8,20 +8,36 @@
 #![cfg(feature = "test-utils")]
 
 use eth_light_client::test_utils::{hex_to_root, ProcessUpdateStep, SpecTestLoader, TestStep};
-use eth_light_client::{ChainSpec, LightClient, UpdateOutcome};
+use eth_light_client::{LightClient, UpdateOutcome};
 
-/// Run spec sync steps 1-5 through the public LightClient API.
 #[test]
-fn test_light_client_public_api_sync() {
+fn test_light_client_public_api_sync_altair() {
+    run_public_api_sync(SpecTestLoader::minimal_altair_sync());
+}
+
+#[test]
+fn test_light_client_public_api_sync_bellatrix() {
+    run_public_api_sync(SpecTestLoader::minimal_bellatrix_sync());
+}
+
+#[test]
+fn test_light_client_public_api_sync_capella() {
+    run_public_api_sync(SpecTestLoader::minimal_capella_sync());
+}
+
+/// Run spec sync steps 1-5 for the given fixture set through the public
+/// `LightClient` API. Shared by the per-fork tests above; the fork is
+/// determined entirely by the supplied `loader`.
+fn run_public_api_sync(loader: SpecTestLoader) {
     println!("\n=== Integration Test: LightClient Public API ===\n");
 
     // Load fixtures using test_utils
-    let loader = SpecTestLoader::minimal_altair_sync();
     let bootstrap = loader.load_bootstrap().expect("Failed to load bootstrap");
     let steps = loader.load_steps().expect("Failed to load steps");
 
-    // Initialize LightClient via public API
-    let mut client = LightClient::new(ChainSpec::minimal(), bootstrap.into_bootstrap())
+    // Use the loader's fork-appropriate ChainSpec so fork version / domain
+    // selection matches the fixtures.
+    let mut client = LightClient::new(loader.chain_spec(), bootstrap.into_bootstrap())
         .expect("Failed to initialize LightClient");
 
     println!(
@@ -72,7 +88,8 @@ fn process_step(
     println!("Processing update: {}", step.update);
     println!(
         "  Attested slot: {}, Signature slot: {}",
-        update.attested_header.slot, update.signature_slot
+        update.attested_header.slot(),
+        update.signature_slot
     );
 
     let before_finalized = client.finalized_header().slot;


### PR DESCRIPTION
Split the single Altair-only public-API sync test into three per-fork tests backed by a shared run_public_api_sync helper, so fork-specific failures are isolated and named. Initialize via loader.chain_spec() instead of a hardcoded minimal spec so fork version / domain selection matches each fixture set.

Also fix a latent compile error surfaced once the test compiles under --features test-utils: attested_header.slot -> attested_header.slot() (slot is a method on the LightClientHeader enum, not a field).