### PR TITLE
refactor: consolidate the spec-test harness helpers into test_utils

### DIFF
--- a/src/consensus/light_client.rs
+++ b/src/consensus/light_client.rs
@@ -295,7 +295,7 @@ impl LightClientProcessor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::consensus::light_client_spec_tests::load_altair_bootstrap;
+    use crate::test_utils::load_altair_bootstrap;
     use crate::types::consensus::SyncAggregate;
 
     fn create_test_beacon_header(slot: Slot) -> BeaconBlockHeader {

--- a/src/consensus/light_client_spec_tests.rs
+++ b/src/consensus/light_client_spec_tests.rs
@@ -4,29 +4,13 @@
 //! Validates the Ethereum light client sync protocol against official
 //! consensus-spec test vectors from https://github.com/ethereum/consensus-spec-tests
 //!
-//! ## Test Organization
-//!
-//! - `test_altair_light_client_sync` — Altair happy path (steps 1-5).
-//! - `test_bellatrix_light_client_sync` — Bellatrix happy path (steps 1-5).
-//! - `test_capella_light_client_sync` — Capella happy path (steps 1-5),
-//!   including execution payload header and execution_root verification.
-//! - `test_altair_light_client_sync_with_force_update` — Full Altair spec test
-//!   including all 10 steps. Currently `#[ignore]` until `force_update` is implemented.
-//!
-//! ## Step Summary
-//!
-//! | Step | Type | What It Tests |
-//! |------|------|---------------|
-//! | 1-5 | process_update | Core sync protocol (happy path) |
-//! | 6 | force_update | Safety timeout (NOT IMPLEMENTED) |
-//! | 7-8 | process_update | Depends on step 6 state |
-//! | 9 | force_update | Safety timeout (NOT IMPLEMENTED) |
-//! | 10 | process_update | Depends on step 9 state |
+//! Each test replays a fork's happy-path steps (1-5, all `process_update`)
+//! through a fresh processor. The vectors also contain `force_update` steps
+//! (6, 9), but `force_update` is not implemented, so those steps are skipped.
 
 use crate::consensus::light_client::LightClientProcessor;
 use crate::test_utils::{
-    beacon_header_matches, hex_to_root, ForceUpdateStep, ProcessUpdateStep, SpecTestLoader,
-    TestStep,
+    beacon_header_matches, hex_to_root, ProcessUpdateStep, SpecTestLoader, TestStep,
 };
 use crate::types::consensus::{LightClientHeader, LightClientUpdate};
 
@@ -107,29 +91,6 @@ fn execute_process_update_step(
     }
 }
 
-fn execute_force_update_step(
-    step_num: usize,
-    step: &ForceUpdateStep,
-    processor: &mut LightClientProcessor,
-) -> bool {
-    println!("  step {}: force_update (not implemented)", step_num);
-
-    let mut step_passed = true;
-
-    if let Some(ref expected) = step.checks.finalized_header {
-        if processor.finalized_header().slot != expected.slot {
-            step_passed = false;
-        }
-    }
-    if let Some(ref expected) = step.checks.optimistic_header {
-        if processor.optimistic_header().slot != expected.slot {
-            step_passed = false;
-        }
-    }
-
-    step_passed
-}
-
 // ============================================================================
 // Shared Helper Functions
 // ============================================================================
@@ -194,144 +155,61 @@ fn check_execution_root(header: &LightClientHeader, expected_hex: &str, label: &
 // Tests
 // ============================================================================
 
-/// Happy path test: runs steps 1-5 only.
-/// Skips force_update steps (6, 9) and steps that depend on them (7, 8, 10).
+/// Replay a fork's happy-path sync steps (1-5, all `process_update`) through a
+/// fresh processor, asserting each passes. Later `force_update` steps are
+/// skipped -- that feature is not implemented.
+fn run_sync(loader: SpecTestLoader, label: &str) {
+    let steps = loader.load_steps().expect("Failed to load steps");
+    let mut processor = initialize_processor_from(&loader);
+    let mut passed = 0;
+    let mut failed = 0;
+
+    println!("{}:", label);
+
+    for (i, step) in steps.iter().enumerate().take(5) {
+        match step {
+            TestStep::ProcessUpdate { process_update } => {
+                let result =
+                    execute_process_update_step(i + 1, process_update, &mut processor, &loader);
+                if result.passed {
+                    passed += 1;
+                } else {
+                    failed += 1;
+                }
+            }
+            TestStep::ForceUpdate { .. } => {
+                println!("  step {}: force_update (skipped, not implemented)", i + 1);
+            }
+        }
+    }
+
+    println!("  result: {}/{} passed", passed, passed + failed);
+    assert_eq!(failed, 0, "{} step(s) failed", failed);
+}
+
+/// Altair happy path (steps 1-5).
 #[test]
 fn test_altair_light_client_sync() {
-    let loader = SpecTestLoader::minimal_altair_sync();
-    let steps = loader.load_steps().expect("Failed to load steps");
-    let mut processor = initialize_processor_from(&loader);
-
-    let mut passed = 0;
-    let mut failed = 0;
-
-    println!("altair light client sync (steps 1-5):");
-
-    for (i, step) in steps.iter().enumerate().take(5) {
-        match step {
-            TestStep::ProcessUpdate { process_update } => {
-                let result =
-                    execute_process_update_step(i + 1, process_update, &mut processor, &loader);
-                if result.passed {
-                    passed += 1;
-                } else {
-                    failed += 1;
-                }
-            }
-            TestStep::ForceUpdate { .. } => {
-                println!("  step {}: force_update (skipped)", i + 1);
-            }
-        }
-    }
-
-    println!("  result: {}/{} passed", passed, passed + failed);
-    assert_eq!(failed, 0, "{} step(s) failed", failed);
+    run_sync(
+        SpecTestLoader::minimal_altair_sync(),
+        "altair light client sync (steps 1-5)",
+    );
 }
 
-/// Bellatrix happy path using real Bellatrix spec fixtures.
-/// Headers are tagged as `LightClientHeader::Bellatrix` and verified
-/// with a Bellatrix-compatible `ChainSpec` (BELLATRIX_FORK_EPOCH=0).
+/// Bellatrix happy path (steps 1-5).
 #[test]
 fn test_bellatrix_light_client_sync() {
-    let loader = SpecTestLoader::minimal_bellatrix_sync();
-    let steps = loader.load_steps().expect("Failed to load steps");
-    let mut processor = initialize_processor_from(&loader);
-
-    let mut passed = 0;
-    let mut failed = 0;
-
-    println!("bellatrix light client sync (steps 1-5):");
-
-    for (i, step) in steps.iter().enumerate().take(5) {
-        match step {
-            TestStep::ProcessUpdate { process_update } => {
-                let result =
-                    execute_process_update_step(i + 1, process_update, &mut processor, &loader);
-                if result.passed {
-                    passed += 1;
-                } else {
-                    failed += 1;
-                }
-            }
-            TestStep::ForceUpdate { .. } => {
-                println!("  step {}: force_update (skipped)", i + 1);
-            }
-        }
-    }
-
-    println!("  result: {}/{} passed", passed, passed + failed);
-    assert_eq!(failed, 0, "{} step(s) failed", failed);
+    run_sync(
+        SpecTestLoader::minimal_bellatrix_sync(),
+        "bellatrix light client sync (steps 1-5)",
+    );
 }
 
-/// Capella happy path using real Capella spec fixtures.
-/// Headers include execution payload and execution_branch verification.
+/// Capella happy path (steps 1-5), incl. execution_root verification.
 #[test]
 fn test_capella_light_client_sync() {
-    let loader = SpecTestLoader::minimal_capella_sync();
-    let steps = loader.load_steps().expect("Failed to load steps");
-    let mut processor = initialize_processor_from(&loader);
-
-    let mut passed = 0;
-    let mut failed = 0;
-
-    println!("capella light client sync (steps 1-5):");
-
-    for (i, step) in steps.iter().enumerate().take(5) {
-        match step {
-            TestStep::ProcessUpdate { process_update } => {
-                let result =
-                    execute_process_update_step(i + 1, process_update, &mut processor, &loader);
-                if result.passed {
-                    passed += 1;
-                } else {
-                    failed += 1;
-                }
-            }
-            TestStep::ForceUpdate { .. } => {
-                println!("  step {}: force_update (skipped)", i + 1);
-            }
-        }
-    }
-
-    println!("  result: {}/{} passed", passed, passed + failed);
-    assert_eq!(failed, 0, "{} step(s) failed", failed);
-}
-
-/// Full spec compliance test including force_update steps.
-/// Currently ignored because force_update is not implemented.
-#[test]
-#[ignore = "force_update not yet implemented"]
-fn test_altair_light_client_sync_with_force_update() {
-    let loader = SpecTestLoader::minimal_altair_sync();
-    let steps = loader.load_steps().expect("Failed to load steps");
-    let mut processor = initialize_processor_from(&loader);
-
-    let mut passed = 0;
-    let mut failed = 0;
-
-    println!("altair light client sync (full, {} steps):", steps.len());
-
-    for (i, step) in steps.iter().enumerate() {
-        match step {
-            TestStep::ProcessUpdate { process_update } => {
-                let result =
-                    execute_process_update_step(i + 1, process_update, &mut processor, &loader);
-                if result.passed {
-                    passed += 1;
-                } else {
-                    failed += 1;
-                }
-            }
-            TestStep::ForceUpdate { force_update } => {
-                if execute_force_update_step(i + 1, force_update, &mut processor) {
-                    passed += 1;
-                } else {
-                    failed += 1;
-                }
-            }
-        }
-    }
-
-    println!("  result: {}/{} passed", passed, passed + failed);
-    assert_eq!(failed, 0, "{} step(s) failed", failed);
+    run_sync(
+        SpecTestLoader::minimal_capella_sync(),
+        "capella light client sync (steps 1-5)",
+    );
 }

--- a/src/consensus/light_client_spec_tests.rs
+++ b/src/consensus/light_client_spec_tests.rs
@@ -27,7 +27,7 @@ use crate::consensus::light_client::LightClientProcessor;
 use crate::test_utils::{
     hex_to_root, ForceUpdateStep, ProcessUpdateStep, SpecTestLoader, TestStep,
 };
-use crate::types::consensus::{LightClientBootstrap, LightClientHeader, LightClientUpdate};
+use crate::types::consensus::{LightClientHeader, LightClientUpdate};
 
 struct StepResult {
     passed: bool,
@@ -165,13 +165,6 @@ fn detect_update_type(update: &LightClientUpdate) -> &'static str {
         (false, true) => "Committee",
         (true, true) => "Combined",
     }
-}
-
-/// Load Altair bootstrap data from test fixtures.
-pub(crate) fn load_altair_bootstrap() -> LightClientBootstrap {
-    let loader = SpecTestLoader::minimal_altair_sync();
-    let bootstrap = loader.load_bootstrap().expect("Failed to load bootstrap");
-    bootstrap.into_bootstrap()
 }
 
 fn initialize_processor_from(loader: &SpecTestLoader) -> LightClientProcessor {

--- a/src/consensus/light_client_spec_tests.rs
+++ b/src/consensus/light_client_spec_tests.rs
@@ -25,7 +25,8 @@
 
 use crate::consensus::light_client::LightClientProcessor;
 use crate::test_utils::{
-    hex_to_root, ForceUpdateStep, ProcessUpdateStep, SpecTestLoader, TestStep,
+    beacon_header_matches, hex_to_root, ForceUpdateStep, ProcessUpdateStep, SpecTestLoader,
+    TestStep,
 };
 use crate::types::consensus::{LightClientHeader, LightClientUpdate};
 
@@ -62,19 +63,8 @@ fn execute_process_update_step(
             let mut step_passed = true;
 
             if let Some(ref expected) = step.checks.finalized_header {
-                let actual_slot = processor.finalized_header().slot;
-                let actual_root = processor
-                    .finalized_header()
-                    .hash_tree_root()
-                    .expect("hash_tree_root");
-                let expected_root =
-                    hex_to_root(&expected.beacon_root).expect("Invalid beacon_root");
-
-                if actual_slot != expected.slot || actual_root != expected_root {
-                    println!(
-                        "    FAIL finalized: expected slot={} got={}",
-                        expected.slot, actual_slot
-                    );
+                if !beacon_header_matches(expected, processor.finalized_header()) {
+                    println!("    FAIL finalized: expected slot={}", expected.slot);
                     step_passed = false;
                 }
 
@@ -90,19 +80,8 @@ fn execute_process_update_step(
             }
 
             if let Some(ref expected) = step.checks.optimistic_header {
-                let actual_slot = processor.optimistic_header().slot;
-                let actual_root = processor
-                    .optimistic_header()
-                    .hash_tree_root()
-                    .expect("hash_tree_root");
-                let expected_root =
-                    hex_to_root(&expected.beacon_root).expect("Invalid beacon_root");
-
-                if actual_slot != expected.slot || actual_root != expected_root {
-                    println!(
-                        "    FAIL optimistic: expected slot={} got={}",
-                        expected.slot, actual_slot
-                    );
+                if !beacon_header_matches(expected, processor.optimistic_header()) {
+                    println!("    FAIL optimistic: expected slot={}", expected.slot);
                     step_passed = false;
                 }
 

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -496,7 +496,7 @@ mod tests {
     // ------------------------------------------------------------------------
 
     // Import the spec test fixture loader
-    use crate::consensus::light_client_spec_tests::load_altair_bootstrap;
+    use crate::test_utils::load_altair_bootstrap;
 
     #[test]
     fn test_light_client_creation() {

--- a/src/test_utils/loader.rs
+++ b/src/test_utils/loader.rs
@@ -139,6 +139,16 @@ impl SpecTestLoader {
     }
 }
 
+/// Load a minimal Altair bootstrap — a convenience for tests that only need a
+/// valid bootstrap for setup.
+#[cfg(test)]
+pub(crate) fn load_altair_bootstrap() -> LightClientBootstrap {
+    SpecTestLoader::minimal_altair_sync()
+        .load_bootstrap()
+        .expect("Failed to load bootstrap")
+        .into_bootstrap()
+}
+
 fn load_ssz_snappy<T>(file_path: &Path) -> Result<T, Box<dyn std::error::Error>>
 where
     T: Deserialize,

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -11,3 +11,6 @@ pub use steps::{
 };
 
 pub(crate) use fork::MinimalPresetFork;
+
+#[cfg(test)]
+pub(crate) use loader::load_altair_bootstrap;

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -7,7 +7,8 @@ mod steps;
 
 pub use loader::{BootstrapData, SpecTestLoader};
 pub use steps::{
-    hex_to_root, ForceUpdateStep, HeaderCheck, ProcessUpdateStep, StateChecks, TestMeta, TestStep,
+    beacon_header_matches, hex_to_root, ForceUpdateStep, HeaderCheck, ProcessUpdateStep,
+    StateChecks, TestMeta, TestStep,
 };
 
 pub(crate) use fork::MinimalPresetFork;

--- a/src/test_utils/steps.rs
+++ b/src/test_utils/steps.rs
@@ -1,5 +1,6 @@
 //! YAML metadata and step types deserialized from spec test fixtures.
 
+use crate::types::consensus::BeaconBlockHeader;
 use crate::types::primitives::Root;
 
 /// Metadata from a spec test's meta.yaml file.
@@ -68,4 +69,16 @@ pub fn hex_to_root(hex: &str) -> Result<Root, Box<dyn std::error::Error>> {
     let mut root = [0u8; 32];
     root.copy_from_slice(&bytes);
     Ok(root)
+}
+
+/// Whether a beacon header matches a fixture `HeaderCheck` (slot + beacon root).
+///
+/// Covers only the beacon check — the part both the internal processor and the
+/// public `LightClient` expose as a `BeaconBlockHeader`. The Capella+
+/// `execution_root` is not checked here, since only the processor exposes the
+/// full light client header.
+pub fn beacon_header_matches(check: &HeaderCheck, header: &BeaconBlockHeader) -> bool {
+    let expected_root = hex_to_root(&check.beacon_root).expect("invalid beacon_root hex");
+    let actual_root = header.hash_tree_root().expect("hash_tree_root");
+    header.slot == check.slot && actual_root == expected_root
 }

--- a/tests/light_client_sync.rs
+++ b/tests/light_client_sync.rs
@@ -7,7 +7,9 @@
 
 #![cfg(feature = "test-utils")]
 
-use eth_light_client::test_utils::{hex_to_root, ProcessUpdateStep, SpecTestLoader, TestStep};
+use eth_light_client::test_utils::{
+    beacon_header_matches, ProcessUpdateStep, SpecTestLoader, TestStep,
+};
 use eth_light_client::{LightClient, UpdateOutcome};
 
 #[test]
@@ -137,43 +139,21 @@ fn process_step(
     let mut step_passed = true;
 
     if let Some(ref expected) = step.checks.finalized_header {
-        if after_finalized != expected.slot {
+        if !beacon_header_matches(expected, client.finalized_header()) {
             println!(
-                "  FAIL: Finalized slot mismatch (expected {}, got {})",
-                expected.slot, after_finalized
+                "  FAIL: Finalized header mismatch (expected slot {})",
+                expected.slot
             );
-            step_passed = false;
-        }
-
-        let actual_root = client
-            .finalized_header()
-            .hash_tree_root()
-            .expect("hash_tree_root failed");
-        let expected_root = hex_to_root(&expected.beacon_root).expect("Invalid beacon_root");
-
-        if actual_root != expected_root {
-            println!("  FAIL: Finalized beacon_root mismatch");
             step_passed = false;
         }
     }
 
     if let Some(ref expected) = step.checks.optimistic_header {
-        if after_optimistic != expected.slot {
+        if !beacon_header_matches(expected, client.optimistic_header()) {
             println!(
-                "  FAIL: Optimistic slot mismatch (expected {}, got {})",
-                expected.slot, after_optimistic
+                "  FAIL: Optimistic header mismatch (expected slot {})",
+                expected.slot
             );
-            step_passed = false;
-        }
-
-        let actual_root = client
-            .optimistic_header()
-            .hash_tree_root()
-            .expect("hash_tree_root failed");
-        let expected_root = hex_to_root(&expected.beacon_root).expect("Invalid beacon_root");
-
-        if actual_root != expected_root {
-            println!("  FAIL: Optimistic beacon_root mismatch");
             step_passed = false;
         }
     }


### PR DESCRIPTION
## Summary

Follow-up to #53. The two spec-test harnesses — `light_client_spec_tests.rs` (drives the internal `LightClientProcessor`) and `tests/light_client_sync.rs` (drives the public `LightClient`) — independently reimplemented the same fixture-loading and assertion logic. This PR moves the shared pieces into `test_utils` and de-duplicates them, then trims a speculative placeholder.

**Test-only** — no production code changes. Net −143 lines.

## Commits (reviewable in sequence)

1. **`refactor: move load_altair_bootstrap fixture helper into test_utils`**
   The helper lived in `light_client_spec_tests.rs` but was imported by unrelated test modules (`light_client.rs`, `consensus/light_client.rs` — 8 call sites) reaching into the consensus spec-tests. Relocated beside `SpecTestLoader`. Stays `#[cfg(test)] pub(crate)` — **no external API change**; no module reaches across for a fixture anymore.

2. **`refactor: share the HeaderCheck beacon assertion across both harnesses`**
   Both harnesses reimplemented "hex-decode the expected `beacon_root`, `hash_tree_root` the actual header, compare slot + root against the fixture `HeaderCheck`" in four places. Extracted into `test_utils::beacon_header_matches(check, header)`, keyed on `HeaderCheck` + `BeaconBlockHeader` (which both clients expose). **This is the one commit that grows the external `test_utils` API** — the integration test in `tests/` consumes it, so it's `pub`. The Capella `execution_root` check stays processor-side (the public `LightClient` can't expose the full header, by design).

3. **`refactor: collapse spec-test fns into a happy-path run_sync helper`**
   The three per-fork test fns were near-identical loops; collapsed into one `run_sync(loader, label)`. Also drops speculative `force_update` scaffolding (`execute_force_update_step` + an `#[ignore]`d full-run test) that tested nothing real — it checked the processor's unchanged state against the expected post-force state, so it would fail; `force_update` isn't implemented. `TestStep::ForceUpdate` / `ForceUpdateStep` stay, since the `steps.yaml` fixtures still contain those steps and must deserialize.

## Why it matters

The duplicated assertion logic was exactly the kind of thing that drifts between copies — the same class of bug as the no-finality divergence fixed in #53. Sharing it gives one place to keep the check correct.

## Testing

Green at every commit, in both feature modes:
- `cargo test` / `cargo test --features test-utils` — 76 unit + 3 integration + 3 doc
- `cargo clippy -- -D warnings` and `cargo clippy --features test-utils -- -D warnings`

## Deliberately out of scope

- Moving `detect_update_type` into `test_utils` — a `println!`-only classification used once; not worth the API surface.
- Merging the two consensus test files — considered and rejected; unit tests vs spec-vector conformance are distinct concerns, and this PR makes them cleanly independent (both lean on `test_utils`).
- Generalizing `load_altair_bootstrap` to take a fork — all callers want the same valid bootstrap; a fork parameter would be flexibility no caller needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)