### PR TITLE
refactor: tighten test_utils API surface

### DIFF
--- a/src/consensus/light_client_spec_tests.rs
+++ b/src/consensus/light_client_spec_tests.rs
@@ -108,10 +108,7 @@ fn detect_update_type(update: &LightClientUpdate) -> &'static str {
 }
 
 fn initialize_processor_from(loader: &SpecTestLoader) -> LightClientProcessor {
-    let bootstrap = loader
-        .load_bootstrap()
-        .expect("Failed to load bootstrap")
-        .into_bootstrap();
+    let bootstrap = loader.load_bootstrap().expect("Failed to load bootstrap");
     let chain_spec = loader.chain_spec();
 
     LightClientProcessor::new(

--- a/src/consensus/merkle.rs
+++ b/src/consensus/merkle.rs
@@ -436,13 +436,13 @@ mod tests {
         let bootstrap = loader.load_bootstrap().expect("Failed to load bootstrap");
 
         // Compute sync committee root using our hardened function
-        let computed_root = compute_sync_committee_root(&spec, &bootstrap.sync_committee);
+        let computed_root = compute_sync_committee_root(&spec, &bootstrap.current_sync_committee);
 
         // Verify against the state root using the branch
         let gindex = spec.current_sync_committee_gindex(bootstrap.header.slot());
         let is_valid = is_valid_merkle_branch(
             &computed_root,
-            &bootstrap.branch,
+            &bootstrap.current_sync_committee_branch,
             gindex,
             bootstrap.header.state_root(),
         )

--- a/src/test_utils/loader.rs
+++ b/src/test_utils/loader.rs
@@ -7,32 +7,10 @@ use super::raw_ssz::{
 };
 use super::steps::{TestMeta, TestStep};
 use super::{hex_to_root, MinimalPresetFork};
-use crate::types::consensus::{
-    LightClientBootstrap, LightClientHeader, LightClientUpdate, SyncCommittee,
-};
-use crate::types::primitives::Root;
+use crate::types::consensus::{LightClientBootstrap, LightClientUpdate};
 use ssz_rs::prelude::*;
 use std::fs;
 use std::path::{Path, PathBuf};
-
-#[derive(Debug, Clone)]
-pub struct BootstrapData {
-    pub header: LightClientHeader,
-    pub sync_committee: SyncCommittee,
-    pub branch: Vec<Root>,
-    pub genesis_validators_root: Root,
-}
-
-impl BootstrapData {
-    pub fn into_bootstrap(self) -> LightClientBootstrap {
-        LightClientBootstrap::from_header(
-            self.header,
-            self.sync_committee,
-            self.branch,
-            self.genesis_validators_root,
-        )
-    }
-}
 
 /// Loads spec test fixtures from a directory.
 ///
@@ -74,7 +52,7 @@ impl SpecTestLoader {
         self.fork.chain_spec()
     }
 
-    pub fn load_bootstrap(&self) -> Result<BootstrapData, Box<dyn std::error::Error>> {
+    pub fn load_bootstrap(&self) -> Result<LightClientBootstrap, Box<dyn std::error::Error>> {
         let meta = self.load_meta()?;
         let genesis_validators_root = hex_to_root(&meta.genesis_validators_root)?;
         let bootstrap_path = self.test_dir.join("bootstrap.ssz_snappy");
@@ -84,13 +62,14 @@ impl SpecTestLoader {
                 let bootstrap: RawLightClientBootstrap = load_ssz_snappy(&bootstrap_path)?;
                 let sync_committee = bootstrap.current_sync_committee.to_sync_committee()?;
                 let branch = nodes_to_roots(&bootstrap.current_sync_committee_branch);
+                let header = raw_beacon_only_header_to_pub(self.fork, bootstrap.header);
 
-                Ok(BootstrapData {
-                    header: raw_beacon_only_header_to_pub(self.fork, bootstrap.header),
+                Ok(LightClientBootstrap::from_header(
+                    header,
                     sync_committee,
                     branch,
                     genesis_validators_root,
-                })
+                ))
             }
             MinimalPresetFork::Capella => {
                 let bootstrap: RawCapellaLightClientBootstrap = load_ssz_snappy(&bootstrap_path)?;
@@ -98,12 +77,12 @@ impl SpecTestLoader {
                 let branch = nodes_to_roots(&bootstrap.current_sync_committee_branch);
                 let header = raw_capella_header_to_pub(bootstrap.header)?;
 
-                Ok(BootstrapData {
+                Ok(LightClientBootstrap::from_header(
                     header,
                     sync_committee,
                     branch,
                     genesis_validators_root,
-                })
+                ))
             }
         }
     }
@@ -146,7 +125,6 @@ pub(crate) fn load_altair_bootstrap() -> LightClientBootstrap {
     SpecTestLoader::minimal_altair_sync()
         .load_bootstrap()
         .expect("Failed to load bootstrap")
-        .into_bootstrap()
 }
 
 fn load_ssz_snappy<T>(file_path: &Path) -> Result<T, Box<dyn std::error::Error>>

--- a/src/test_utils/loader.rs
+++ b/src/test_utils/loader.rs
@@ -124,7 +124,7 @@ impl SpecTestLoader {
         }
     }
 
-    pub fn load_meta(&self) -> Result<TestMeta, Box<dyn std::error::Error>> {
+    pub(crate) fn load_meta(&self) -> Result<TestMeta, Box<dyn std::error::Error>> {
         let meta_path = self.test_dir.join("meta.yaml");
         let meta_contents = fs::read_to_string(&meta_path)?;
         let meta: TestMeta = serde_yaml::from_str(&meta_contents)?;

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -6,9 +6,7 @@ mod raw_ssz;
 mod steps;
 
 pub use loader::{BootstrapData, SpecTestLoader};
-pub use steps::{
-    beacon_header_matches, ForceUpdateStep, HeaderCheck, ProcessUpdateStep, StateChecks, TestStep,
-};
+pub use steps::{beacon_header_matches, HeaderCheck, ProcessUpdateStep, StateChecks, TestStep};
 
 pub(crate) use fork::MinimalPresetFork;
 pub(crate) use steps::hex_to_root;

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -5,7 +5,7 @@ mod loader;
 mod raw_ssz;
 mod steps;
 
-pub use loader::{BootstrapData, SpecTestLoader};
+pub use loader::SpecTestLoader;
 pub use steps::{beacon_header_matches, HeaderCheck, ProcessUpdateStep, StateChecks, TestStep};
 
 pub(crate) use fork::MinimalPresetFork;

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -7,11 +7,11 @@ mod steps;
 
 pub use loader::{BootstrapData, SpecTestLoader};
 pub use steps::{
-    beacon_header_matches, hex_to_root, ForceUpdateStep, HeaderCheck, ProcessUpdateStep,
-    StateChecks, TestMeta, TestStep,
+    beacon_header_matches, ForceUpdateStep, HeaderCheck, ProcessUpdateStep, StateChecks, TestStep,
 };
 
 pub(crate) use fork::MinimalPresetFork;
+pub(crate) use steps::hex_to_root;
 
 #[cfg(test)]
 pub(crate) use loader::load_altair_bootstrap;

--- a/src/test_utils/steps.rs
+++ b/src/test_utils/steps.rs
@@ -4,15 +4,15 @@ use crate::types::consensus::BeaconBlockHeader;
 use crate::types::primitives::Root;
 
 /// Metadata from a spec test's meta.yaml file.
+///
+/// The fork-digest keys are unmodeled; serde ignores them (fork comes from the
+/// `SpecTestLoader` constructor).
 #[derive(Debug, serde::Deserialize)]
 pub(crate) struct TestMeta {
     pub(crate) genesis_validators_root: String,
+    /// Parsed but not yet enforced; see issue #55.
     #[allow(dead_code)]
     trusted_block_root: String,
-    #[allow(dead_code)]
-    bootstrap_fork_digest: String,
-    #[allow(dead_code)]
-    store_fork_digest: String,
 }
 
 #[derive(Debug, serde::Deserialize)]

--- a/src/test_utils/steps.rs
+++ b/src/test_utils/steps.rs
@@ -5,8 +5,8 @@ use crate::types::primitives::Root;
 
 /// Metadata from a spec test's meta.yaml file.
 #[derive(Debug, serde::Deserialize)]
-pub struct TestMeta {
-    pub genesis_validators_root: String,
+pub(crate) struct TestMeta {
+    pub(crate) genesis_validators_root: String,
     #[allow(dead_code)]
     trusted_block_root: String,
     #[allow(dead_code)]
@@ -60,7 +60,7 @@ pub struct ForceUpdateStep {
 }
 
 /// Convert a hex string (with or without 0x prefix) to a 32-byte root.
-pub fn hex_to_root(hex: &str) -> Result<Root, Box<dyn std::error::Error>> {
+pub(crate) fn hex_to_root(hex: &str) -> Result<Root, Box<dyn std::error::Error>> {
     let hex = hex.strip_prefix("0x").unwrap_or(hex);
     let bytes = hex::decode(hex)?;
     if bytes.len() != 32 {

--- a/src/test_utils/steps.rs
+++ b/src/test_utils/steps.rs
@@ -37,9 +37,8 @@ pub enum TestStep {
     ProcessUpdate {
         process_update: ProcessUpdateStep,
     },
-    /// Force update (safety timeout mechanism).
     ForceUpdate {
-        force_update: ForceUpdateStep,
+        force_update: serde::de::IgnoredAny,
     },
 }
 
@@ -49,12 +48,6 @@ pub struct ProcessUpdateStep {
     update_fork_digest: String,
     /// Update file name (without .ssz_snappy extension).
     pub update: String,
-    pub current_slot: u64,
-    pub checks: StateChecks,
-}
-
-#[derive(Debug, serde::Deserialize)]
-pub struct ForceUpdateStep {
     pub current_slot: u64,
     pub checks: StateChecks,
 }

--- a/src/test_utils/steps.rs
+++ b/src/test_utils/steps.rs
@@ -34,12 +34,8 @@ pub struct HeaderCheck {
 #[derive(Debug, serde::Deserialize)]
 #[serde(untagged)]
 pub enum TestStep {
-    ProcessUpdate {
-        process_update: ProcessUpdateStep,
-    },
-    ForceUpdate {
-        force_update: serde::de::IgnoredAny,
-    },
+    ProcessUpdate { process_update: ProcessUpdateStep },
+    ForceUpdate { force_update: serde::de::IgnoredAny },
 }
 
 #[derive(Debug, serde::Deserialize)]

--- a/tests/light_client_sync.rs
+++ b/tests/light_client_sync.rs
@@ -39,8 +39,8 @@ fn run_public_api_sync(loader: SpecTestLoader) {
 
     // Use the loader's fork-appropriate ChainSpec so fork version / domain
     // selection matches the fixtures.
-    let mut client = LightClient::new(loader.chain_spec(), bootstrap.into_bootstrap())
-        .expect("Failed to initialize LightClient");
+    let mut client =
+        LightClient::new(loader.chain_spec(), bootstrap).expect("Failed to initialize LightClient");
 
     println!(
         "Initialized at slot {} (period {})",


### PR DESCRIPTION
Cleans up the `test_utils` fixture harness API after the recent module split.

This PR:
- tightens `hex_to_root`, `TestMeta`, and `load_meta` from public to crate-internal where external usage is gone or never existed
- trims `TestMeta` to the fields the loader actually reads
- removes the unused `ForceUpdateStep` struct while still accepting `force_update` fixture steps
- collapses the redundant `BootstrapData` staging type into `LightClientBootstrap`
- updates callers to use the production bootstrap type directly

No production light-client behavior changes. This only affects test fixture loading / unstable `test-utils` helpers.

Validation:
- `cargo fmt`
- `cargo test`
- `cargo test --features test-utils --test light_client_sync`
- `cargo clippy -- -D warnings`
- `cargo clippy --features test-utils -- -D warnings`