### PR TITLE
refactor: light client spec-test harness cleanup + consensus README

### DIFF
--- a/src/consensus/README.md
+++ b/src/consensus/README.md
@@ -1,0 +1,48 @@
+# Consensus
+
+Core consensus-layer verification for the light client: BLS signatures, Merkle
+proofs, sync-committee validation, and the light-client sync state machine.
+
+> **Note:** This README currently documents only the module's **testing** setup.
+> A broader overview of the consensus components is still to be written.
+
+## Testing
+
+The consensus tests split along two **orthogonal** axes — *scope* (what a test
+exercises) and, for the end-to-end tests, *surface* (which API it drives). A
+third property, *whether a test uses official spec fixtures*, cuts across both.
+
+### Scope
+
+| Scope | What it does | Where |
+|-------|--------------|-------|
+| **Unit** | Exercises one function/method in isolation. | `bls.rs`, `merkle.rs`, `sync_committee.rs`, `light_client.rs` |
+| **Conformance replay** | Bootstraps a store and replays the official `light_client_sync` step sequence (updates + expected post-state) end-to-end. | `light_client_spec_tests.rs` (+ its public-API counterpart under `tests/`) |
+
+A conformance replay is *not* a unit test even though it lives in a
+`#[cfg(test)]` module: in Rust, `src/` vs `tests/` decides **access** (can it see
+`pub(crate)` internals?), not **scope**.
+
+### Surface — conformance replays only
+
+Both replays run the *same* spec vectors; they differ only in which API surface
+they drive, which is why both exist. They are complementary, not redundant.
+
+| Surface | Driver / test names | Notes |
+|---------|---------------------|-------|
+| **Internal processor** | `light_client_spec_tests.rs` — `run_processor_sync`, `<fork>_sync_via_processor` | Drives `LightClientProcessor` (`pub(crate)`); also verifies Capella execution roots via the fork-aware header. |
+| **Public API** | `tests/light_client_sync.rs` — `run_public_api_sync`, `<fork>_sync_via_public_api` | Drives the public `LightClient` with public types only; also checks the `UpdateOutcome` contract. Lives in the integration-test crate, outside this module. |
+
+### "Spec test" is orthogonal to scope
+
+A *spec test* uses official Ethereum consensus fixtures — independent of scope.
+Fixtures appear at **unit** scope too, not just in the replays:
+
+- `bls_spec_tests.rs` — official BLS `verify` / `fast_aggregate_verify` vectors, each driving a single function.
+- `merkle.rs::test_sync_committee_root_against_spec_fixture` — one sync-committee root + branch, checked against a bootstrap fixture.
+
+So "spec test", "unit test", and "the sync replay" are three different
+properties that cut across one another.
+
+Fixtures are loaded off disk by the `test_utils` module (see its README); the
+consensus tests only consume the typed objects it returns.

--- a/src/consensus/light_client_spec_tests.rs
+++ b/src/consensus/light_client_spec_tests.rs
@@ -5,72 +5,49 @@
 //! consensus-spec test vectors from https://github.com/ethereum/consensus-spec-tests
 //!
 //! Each test replays a fork's happy-path steps (1-5, all `process_update`)
-//! through a fresh processor. The vectors also contain `force_update` steps
+//! through a fresh processor, asserting the resulting store state against the
+//! fixture's expected headers. The vectors also contain `force_update` steps
 //! (6, 9), but `force_update` is not implemented, so those steps are skipped.
 
 use crate::consensus::light_client::LightClientProcessor;
 use crate::test_utils::{
     beacon_header_matches, hex_to_root, ProcessUpdateStep, SpecTestLoader, TestStep,
 };
-use crate::types::consensus::{LightClientHeader, LightClientUpdate};
+use crate::types::consensus::LightClientHeader;
 
 /// Altair happy path (steps 1-5).
 #[test]
 fn test_altair_light_client_sync() {
-    run_sync(
-        SpecTestLoader::minimal_altair_sync(),
-        "altair light client sync (steps 1-5)",
-    );
+    run_sync(SpecTestLoader::minimal_altair_sync());
 }
 
 /// Bellatrix happy path (steps 1-5).
 #[test]
 fn test_bellatrix_light_client_sync() {
-    run_sync(
-        SpecTestLoader::minimal_bellatrix_sync(),
-        "bellatrix light client sync (steps 1-5)",
-    );
+    run_sync(SpecTestLoader::minimal_bellatrix_sync());
 }
 
 /// Capella happy path (steps 1-5), incl. execution_root verification.
 #[test]
 fn test_capella_light_client_sync() {
-    run_sync(
-        SpecTestLoader::minimal_capella_sync(),
-        "capella light client sync (steps 1-5)",
-    );
+    run_sync(SpecTestLoader::minimal_capella_sync());
 }
 
 /// Replay a fork's happy-path sync steps (1-5, all `process_update`) through a
-/// fresh processor, asserting each passes. Later `force_update` steps are
-/// skipped -- that feature is not implemented.
-fn run_sync(loader: SpecTestLoader, label: &str) {
+/// fresh processor, asserting each against the fixture's expected state. Later
+/// `force_update` steps are skipped -- that feature is not implemented.
+fn run_sync(loader: SpecTestLoader) {
     let steps = loader.load_steps().expect("Failed to load steps");
     let mut processor = initialize_processor_from(&loader);
-    let mut passed = 0;
-    let mut failed = 0;
-
-    println!("{}:", label);
 
     for (i, step) in steps.iter().enumerate().take(5) {
         match step {
             TestStep::ProcessUpdate { process_update } => {
-                let result =
-                    execute_process_update_step(i + 1, process_update, &mut processor, &loader);
-                if result.passed {
-                    passed += 1;
-                } else {
-                    failed += 1;
-                }
+                execute_process_update_step(i + 1, process_update, &mut processor, &loader);
             }
-            TestStep::ForceUpdate { .. } => {
-                println!("  step {}: force_update (skipped, not implemented)", i + 1);
-            }
+            TestStep::ForceUpdate { .. } => {} // not implemented -- skip
         }
     }
-
-    println!("  result: {}/{} passed", passed, passed + failed);
-    assert_eq!(failed, 0, "{} step(s) failed", failed);
 }
 
 fn initialize_processor_from(loader: &SpecTestLoader) -> LightClientProcessor {
@@ -87,118 +64,80 @@ fn initialize_processor_from(loader: &SpecTestLoader) -> LightClientProcessor {
     .expect("Failed to initialize LightClientProcessor")
 }
 
-struct StepResult {
-    passed: bool,
-}
-
 fn execute_process_update_step(
     step_num: usize,
     step: &ProcessUpdateStep,
     processor: &mut LightClientProcessor,
     loader: &SpecTestLoader,
-) -> StepResult {
-    let update = match loader.load_update(&step.update) {
-        Ok(u) => u,
-        Err(e) => {
-            println!("  step {}: FAIL - load error: {}", step_num, e);
-            return StepResult { passed: false };
+) {
+    let update = loader.load_update(&step.update).unwrap_or_else(|e| {
+        panic!(
+            "step {}: failed to load update {}: {}",
+            step_num, step.update, e
+        )
+    });
+
+    processor
+        .process_update_at_slot(update, step.current_slot)
+        .unwrap_or_else(|e| panic!("step {}: process error: {}", step_num, e));
+
+    if let Some(expected) = &step.checks.finalized_header {
+        assert!(
+            beacon_header_matches(expected, processor.finalized_header()),
+            "step {}: finalized header mismatch (expected slot {})",
+            step_num,
+            expected.slot,
+        );
+        if let Some(expected_exec_root) = &expected.execution_root {
+            assert_execution_root(
+                processor.finalized_light_client_header(),
+                expected_exec_root,
+                "finalized",
+                step_num,
+            );
         }
-    };
+    }
 
-    let update_type = detect_update_type(&update);
-    println!(
-        "  step {}: {} (attested={}, sig={}, current_slot={})",
-        step_num,
-        update_type,
-        update.attested_header.slot(),
-        update.signature_slot,
-        step.current_slot,
-    );
-
-    match processor.process_update_at_slot(update, step.current_slot) {
-        Ok(_state_changed) => {
-            let mut step_passed = true;
-
-            if let Some(ref expected) = step.checks.finalized_header {
-                if !beacon_header_matches(expected, processor.finalized_header()) {
-                    println!("    FAIL finalized: expected slot={}", expected.slot);
-                    step_passed = false;
-                }
-
-                if let Some(ref expected_exec_root) = expected.execution_root {
-                    if !check_execution_root(
-                        processor.finalized_light_client_header(),
-                        expected_exec_root,
-                        "finalized",
-                    ) {
-                        step_passed = false;
-                    }
-                }
-            }
-
-            if let Some(ref expected) = step.checks.optimistic_header {
-                if !beacon_header_matches(expected, processor.optimistic_header()) {
-                    println!("    FAIL optimistic: expected slot={}", expected.slot);
-                    step_passed = false;
-                }
-
-                if let Some(ref expected_exec_root) = expected.execution_root {
-                    if !check_execution_root(
-                        processor.optimistic_light_client_header(),
-                        expected_exec_root,
-                        "optimistic",
-                    ) {
-                        step_passed = false;
-                    }
-                }
-            }
-
-            StepResult {
-                passed: step_passed,
-            }
-        }
-        Err(e) => {
-            println!("    FAIL: process error: {}", e);
-            StepResult { passed: false }
+    if let Some(expected) = &step.checks.optimistic_header {
+        assert!(
+            beacon_header_matches(expected, processor.optimistic_header()),
+            "step {}: optimistic header mismatch (expected slot {})",
+            step_num,
+            expected.slot,
+        );
+        if let Some(expected_exec_root) = &expected.execution_root {
+            assert_execution_root(
+                processor.optimistic_light_client_header(),
+                expected_exec_root,
+                "optimistic",
+                step_num,
+            );
         }
     }
 }
 
-fn detect_update_type(update: &LightClientUpdate) -> &'static str {
-    match (
-        update.finalized_header.is_some(),
-        update.next_sync_committee.is_some(),
-    ) {
-        (false, false) => "Optimistic",
-        (true, false) => "Finality",
-        (false, true) => "Committee",
-        (true, true) => "Combined",
-    }
-}
-
-fn check_execution_root(header: &LightClientHeader, expected_hex: &str, label: &str) -> bool {
+fn assert_execution_root(
+    header: &LightClientHeader,
+    expected_hex: &str,
+    label: &str,
+    step_num: usize,
+) {
     let expected = hex_to_root(expected_hex).expect("Invalid execution_root hex");
     match header {
         LightClientHeader::Capella(h) => {
             let actual = h.execution.hash_tree_root();
-            if actual != expected {
-                println!(
-                    "    FAIL {} execution_root: expected {} got {}",
-                    label,
-                    hex::encode(expected),
-                    hex::encode(actual),
-                );
-                return false;
-            }
-            true
-        }
-        _ => {
-            // Altair/Bellatrix headers shouldn't have execution_root checks
-            println!(
-                "    FAIL {}: execution_root check on non-Capella header",
-                label
+            assert!(
+                actual == expected,
+                "step {}: {} execution_root mismatch: expected {}, got {}",
+                step_num,
+                label,
+                hex::encode(expected),
+                hex::encode(actual),
             );
-            false
         }
+        _ => panic!(
+            "step {}: {} execution_root check on non-Capella header",
+            step_num, label
+        ),
     }
 }

--- a/src/consensus/light_client_spec_tests.rs
+++ b/src/consensus/light_client_spec_tests.rs
@@ -17,26 +17,26 @@ use crate::types::consensus::LightClientHeader;
 
 /// Altair happy path (steps 1-5).
 #[test]
-fn test_altair_light_client_sync() {
-    run_sync(SpecTestLoader::minimal_altair_sync());
+fn altair_sync_via_processor() {
+    run_processor_sync(SpecTestLoader::minimal_altair_sync());
 }
 
 /// Bellatrix happy path (steps 1-5).
 #[test]
-fn test_bellatrix_light_client_sync() {
-    run_sync(SpecTestLoader::minimal_bellatrix_sync());
+fn bellatrix_sync_via_processor() {
+    run_processor_sync(SpecTestLoader::minimal_bellatrix_sync());
 }
 
 /// Capella happy path (steps 1-5), incl. execution_root verification.
 #[test]
-fn test_capella_light_client_sync() {
-    run_sync(SpecTestLoader::minimal_capella_sync());
+fn capella_sync_via_processor() {
+    run_processor_sync(SpecTestLoader::minimal_capella_sync());
 }
 
 /// Replay a fork's happy-path sync steps (1-5, all `process_update`) through a
 /// fresh processor, asserting each against the fixture's expected state. Later
 /// `force_update` steps are skipped -- that feature is not implemented.
-fn run_sync(loader: SpecTestLoader) {
+fn run_processor_sync(loader: SpecTestLoader) {
     let steps = loader.load_steps().expect("Failed to load steps");
     let mut processor = initialize_processor_from(&loader);
 

--- a/src/consensus/light_client_spec_tests.rs
+++ b/src/consensus/light_client_spec_tests.rs
@@ -14,6 +14,79 @@ use crate::test_utils::{
 };
 use crate::types::consensus::{LightClientHeader, LightClientUpdate};
 
+/// Altair happy path (steps 1-5).
+#[test]
+fn test_altair_light_client_sync() {
+    run_sync(
+        SpecTestLoader::minimal_altair_sync(),
+        "altair light client sync (steps 1-5)",
+    );
+}
+
+/// Bellatrix happy path (steps 1-5).
+#[test]
+fn test_bellatrix_light_client_sync() {
+    run_sync(
+        SpecTestLoader::minimal_bellatrix_sync(),
+        "bellatrix light client sync (steps 1-5)",
+    );
+}
+
+/// Capella happy path (steps 1-5), incl. execution_root verification.
+#[test]
+fn test_capella_light_client_sync() {
+    run_sync(
+        SpecTestLoader::minimal_capella_sync(),
+        "capella light client sync (steps 1-5)",
+    );
+}
+
+/// Replay a fork's happy-path sync steps (1-5, all `process_update`) through a
+/// fresh processor, asserting each passes. Later `force_update` steps are
+/// skipped -- that feature is not implemented.
+fn run_sync(loader: SpecTestLoader, label: &str) {
+    let steps = loader.load_steps().expect("Failed to load steps");
+    let mut processor = initialize_processor_from(&loader);
+    let mut passed = 0;
+    let mut failed = 0;
+
+    println!("{}:", label);
+
+    for (i, step) in steps.iter().enumerate().take(5) {
+        match step {
+            TestStep::ProcessUpdate { process_update } => {
+                let result =
+                    execute_process_update_step(i + 1, process_update, &mut processor, &loader);
+                if result.passed {
+                    passed += 1;
+                } else {
+                    failed += 1;
+                }
+            }
+            TestStep::ForceUpdate { .. } => {
+                println!("  step {}: force_update (skipped, not implemented)", i + 1);
+            }
+        }
+    }
+
+    println!("  result: {}/{} passed", passed, passed + failed);
+    assert_eq!(failed, 0, "{} step(s) failed", failed);
+}
+
+fn initialize_processor_from(loader: &SpecTestLoader) -> LightClientProcessor {
+    let bootstrap = loader.load_bootstrap().expect("Failed to load bootstrap");
+    let chain_spec = loader.chain_spec();
+
+    LightClientProcessor::new(
+        chain_spec,
+        bootstrap.header.clone(),
+        bootstrap.current_sync_committee,
+        &bootstrap.current_sync_committee_branch,
+        bootstrap.genesis_validators_root,
+    )
+    .expect("Failed to initialize LightClientProcessor")
+}
+
 struct StepResult {
     passed: bool,
 }
@@ -91,10 +164,6 @@ fn execute_process_update_step(
     }
 }
 
-// ============================================================================
-// Shared Helper Functions
-// ============================================================================
-
 fn detect_update_type(update: &LightClientUpdate) -> &'static str {
     match (
         update.finalized_header.is_some(),
@@ -105,20 +174,6 @@ fn detect_update_type(update: &LightClientUpdate) -> &'static str {
         (false, true) => "Committee",
         (true, true) => "Combined",
     }
-}
-
-fn initialize_processor_from(loader: &SpecTestLoader) -> LightClientProcessor {
-    let bootstrap = loader.load_bootstrap().expect("Failed to load bootstrap");
-    let chain_spec = loader.chain_spec();
-
-    LightClientProcessor::new(
-        chain_spec,
-        bootstrap.header.clone(),
-        bootstrap.current_sync_committee,
-        &bootstrap.current_sync_committee_branch,
-        bootstrap.genesis_validators_root,
-    )
-    .expect("Failed to initialize LightClientProcessor")
 }
 
 fn check_execution_root(header: &LightClientHeader, expected_hex: &str, label: &str) -> bool {
@@ -146,67 +201,4 @@ fn check_execution_root(header: &LightClientHeader, expected_hex: &str, label: &
             false
         }
     }
-}
-
-// ============================================================================
-// Tests
-// ============================================================================
-
-/// Replay a fork's happy-path sync steps (1-5, all `process_update`) through a
-/// fresh processor, asserting each passes. Later `force_update` steps are
-/// skipped -- that feature is not implemented.
-fn run_sync(loader: SpecTestLoader, label: &str) {
-    let steps = loader.load_steps().expect("Failed to load steps");
-    let mut processor = initialize_processor_from(&loader);
-    let mut passed = 0;
-    let mut failed = 0;
-
-    println!("{}:", label);
-
-    for (i, step) in steps.iter().enumerate().take(5) {
-        match step {
-            TestStep::ProcessUpdate { process_update } => {
-                let result =
-                    execute_process_update_step(i + 1, process_update, &mut processor, &loader);
-                if result.passed {
-                    passed += 1;
-                } else {
-                    failed += 1;
-                }
-            }
-            TestStep::ForceUpdate { .. } => {
-                println!("  step {}: force_update (skipped, not implemented)", i + 1);
-            }
-        }
-    }
-
-    println!("  result: {}/{} passed", passed, passed + failed);
-    assert_eq!(failed, 0, "{} step(s) failed", failed);
-}
-
-/// Altair happy path (steps 1-5).
-#[test]
-fn test_altair_light_client_sync() {
-    run_sync(
-        SpecTestLoader::minimal_altair_sync(),
-        "altair light client sync (steps 1-5)",
-    );
-}
-
-/// Bellatrix happy path (steps 1-5).
-#[test]
-fn test_bellatrix_light_client_sync() {
-    run_sync(
-        SpecTestLoader::minimal_bellatrix_sync(),
-        "bellatrix light client sync (steps 1-5)",
-    );
-}
-
-/// Capella happy path (steps 1-5), incl. execution_root verification.
-#[test]
-fn test_capella_light_client_sync() {
-    run_sync(
-        SpecTestLoader::minimal_capella_sync(),
-        "capella light client sync (steps 1-5)",
-    );
 }

--- a/src/consensus/light_client_spec_tests.rs
+++ b/src/consensus/light_client_spec_tests.rs
@@ -4,10 +4,9 @@
 //! Validates the Ethereum light client sync protocol against official
 //! consensus-spec test vectors from https://github.com/ethereum/consensus-spec-tests
 //!
-//! Each test replays a fork's happy-path steps (1-5, all `process_update`)
-//! through a fresh processor, asserting the resulting store state against the
-//! fixture's expected headers. The vectors also contain `force_update` steps
-//! (6, 9), but `force_update` is not implemented, so those steps are skipped.
+//! Each test replays a fork's `process_update` steps through a fresh processor,
+//! asserting store state against the fixture. Stops at the first `force_update`:
+//! it's unimplemented and later steps depend on its state transition.
 
 use crate::consensus::light_client::LightClientProcessor;
 use crate::test_utils::{
@@ -15,39 +14,42 @@ use crate::test_utils::{
 };
 use crate::types::consensus::LightClientHeader;
 
-/// Altair happy path (steps 1-5).
 #[test]
 fn altair_sync_via_processor() {
     run_processor_sync(SpecTestLoader::minimal_altair_sync());
 }
 
-/// Bellatrix happy path (steps 1-5).
 #[test]
 fn bellatrix_sync_via_processor() {
     run_processor_sync(SpecTestLoader::minimal_bellatrix_sync());
 }
 
-/// Capella happy path (steps 1-5), incl. execution_root verification.
+/// Capella additionally verifies execution roots.
 #[test]
 fn capella_sync_via_processor() {
     run_processor_sync(SpecTestLoader::minimal_capella_sync());
 }
 
-/// Replay a fork's happy-path sync steps (1-5, all `process_update`) through a
-/// fresh processor, asserting each against the fixture's expected state. Later
-/// `force_update` steps are skipped -- that feature is not implemented.
+/// Replay a fork's `process_update` steps, asserting each against the fixture.
 fn run_processor_sync(loader: SpecTestLoader) {
     let steps = loader.load_steps().expect("Failed to load steps");
     let mut processor = initialize_processor_from(&loader);
 
-    for (i, step) in steps.iter().enumerate().take(5) {
+    let mut processed = 0;
+    for (i, step) in steps.iter().enumerate() {
         match step {
             TestStep::ProcessUpdate { process_update } => {
                 execute_process_update_step(i + 1, process_update, &mut processor, &loader);
+                processed += 1;
             }
-            TestStep::ForceUpdate { .. } => {} // not implemented -- skip
+            // later steps depend on force_update's transition -- stop, don't skip
+            TestStep::ForceUpdate { .. } => break,
         }
     }
+    assert!(
+        processed > 0,
+        "no process_update steps ran before the first force_update"
+    );
 }
 
 fn initialize_processor_from(loader: &SpecTestLoader) -> LightClientProcessor {

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("README.md")]
+
 pub mod bls;
 pub mod light_client;
 pub mod merkle;

--- a/tests/light_client_sync.rs
+++ b/tests/light_client_sync.rs
@@ -27,26 +27,30 @@ fn capella_sync_via_public_api() {
     run_public_api_sync(SpecTestLoader::minimal_capella_sync());
 }
 
-/// Run spec sync steps 1-5 for the given fixture set through the public
-/// `LightClient` API. Shared by the per-fork tests above; the fork is
-/// determined entirely by the supplied `loader`.
+/// Replay the fixture's `process_update` steps through the public `LightClient`
+/// API; the fork is determined by `loader`.
 fn run_public_api_sync(loader: SpecTestLoader) {
     let bootstrap = loader.load_bootstrap().expect("Failed to load bootstrap");
     let steps = loader.load_steps().expect("Failed to load steps");
 
-    // Use the loader's fork-appropriate ChainSpec so fork version / domain
-    // selection matches the fixtures.
     let mut client =
         LightClient::new(loader.chain_spec(), bootstrap).expect("Failed to initialize LightClient");
 
-    for (i, step) in steps.iter().enumerate().take(5) {
+    let mut processed = 0;
+    for (i, step) in steps.iter().enumerate() {
         match step {
             TestStep::ProcessUpdate { process_update } => {
                 process_step(&mut client, &loader, process_update, i + 1);
+                processed += 1;
             }
-            TestStep::ForceUpdate { .. } => {} // not implemented -- skip
+            // later steps depend on force_update's transition -- stop, don't skip
+            TestStep::ForceUpdate { .. } => break,
         }
     }
+    assert!(
+        processed > 0,
+        "no process_update steps ran before the first force_update"
+    );
 }
 
 fn process_step(
@@ -62,7 +66,6 @@ fn process_step(
     let before_finalized = client.finalized_header().slot;
     let before_optimistic = client.optimistic_header().slot;
 
-    // Process update via public API with the fixture's current_slot.
     let outcome: UpdateOutcome = client
         .process_update_at_slot(update, step.current_slot)
         .unwrap_or_else(|e| panic!("step {}: error processing update: {}", step_num, e));
@@ -86,7 +89,6 @@ fn process_step(
         );
     }
 
-    // Observed headers must match the fixture's expected headers.
     if let Some(expected) = &step.checks.finalized_header {
         assert!(
             beacon_header_matches(expected, client.finalized_header()),

--- a/tests/light_client_sync.rs
+++ b/tests/light_client_sync.rs
@@ -31,9 +31,6 @@ fn test_light_client_public_api_sync_capella() {
 /// `LightClient` API. Shared by the per-fork tests above; the fork is
 /// determined entirely by the supplied `loader`.
 fn run_public_api_sync(loader: SpecTestLoader) {
-    println!("\n=== Integration Test: LightClient Public API ===\n");
-
-    // Load fixtures using test_utils
     let bootstrap = loader.load_bootstrap().expect("Failed to load bootstrap");
     let steps = loader.load_steps().expect("Failed to load steps");
 
@@ -42,39 +39,14 @@ fn run_public_api_sync(loader: SpecTestLoader) {
     let mut client =
         LightClient::new(loader.chain_spec(), bootstrap).expect("Failed to initialize LightClient");
 
-    println!(
-        "Initialized at slot {} (period {})",
-        client.finalized_header().slot,
-        client.current_period()
-    );
-
-    // Process steps 1-5
-    let mut passed = 0;
-    let mut failed = 0;
-
     for (i, step) in steps.iter().enumerate().take(5) {
-        let step_num = i + 1;
-
         match step {
             TestStep::ProcessUpdate { process_update } => {
-                println!("\n--- Step {} ---", step_num);
-                if process_step(&mut client, &loader, process_update, step_num) {
-                    passed += 1;
-                } else {
-                    failed += 1;
-                }
+                process_step(&mut client, &loader, process_update, i + 1);
             }
-            TestStep::ForceUpdate { .. } => {
-                println!("\n--- Step {} (force_update: skipped) ---", step_num);
-            }
+            TestStep::ForceUpdate { .. } => {} // not implemented -- skip
         }
     }
-
-    println!("\n=== Results ===");
-    println!("Passed: {}", passed);
-    println!("Failed: {}", failed);
-
-    assert_eq!(failed, 0, "{} step(s) failed", failed);
 }
 
 fn process_step(
@@ -82,85 +54,53 @@ fn process_step(
     loader: &SpecTestLoader,
     step: &ProcessUpdateStep,
     step_num: usize,
-) -> bool {
+) {
     let update = loader
         .load_update(&step.update)
         .expect("Failed to load update");
 
-    println!("Processing update: {}", step.update);
-    println!(
-        "  Attested slot: {}, Signature slot: {}",
-        update.attested_header.slot(),
-        update.signature_slot
-    );
-
     let before_finalized = client.finalized_header().slot;
     let before_optimistic = client.optimistic_header().slot;
 
-    // Process update via public API with fixture's current_slot
-    let outcome: UpdateOutcome = match client.process_update_at_slot(update, step.current_slot) {
-        Ok(outcome) => outcome,
-        Err(e) => {
-            println!("  FAIL: Error processing update: {}", e);
-            return false;
-        }
-    };
+    // Process update via public API with the fixture's current_slot.
+    let outcome: UpdateOutcome = client
+        .process_update_at_slot(update, step.current_slot)
+        .unwrap_or_else(|e| panic!("step {}: error processing update: {}", step_num, e));
 
     let after_finalized = client.finalized_header().slot;
     let after_optimistic = client.optimistic_header().slot;
 
-    println!(
-        "  Before: finalized={}, optimistic={}",
-        before_finalized, before_optimistic
-    );
-    println!(
-        "  After:  finalized={}, optimistic={}",
-        after_finalized, after_optimistic
-    );
-    println!("  Outcome: {:?}", outcome);
-
-    // Verify UpdateOutcome consistency
+    // UpdateOutcome must agree with observed state.
     if outcome.finalized_updated() {
         assert!(
             after_finalized > before_finalized,
-            "Step {}: finalized_updated()=true but slot didn't advance",
+            "step {}: finalized_updated()=true but slot didn't advance",
             step_num
         );
     }
     if outcome.optimistic_updated() {
         assert!(
             after_optimistic > before_optimistic,
-            "Step {}: optimistic_updated()=true but slot didn't advance",
+            "step {}: optimistic_updated()=true but slot didn't advance",
             step_num
         );
     }
 
-    // Verify against expected state
-    let mut step_passed = true;
-
-    if let Some(ref expected) = step.checks.finalized_header {
-        if !beacon_header_matches(expected, client.finalized_header()) {
-            println!(
-                "  FAIL: Finalized header mismatch (expected slot {})",
-                expected.slot
-            );
-            step_passed = false;
-        }
+    // Observed headers must match the fixture's expected headers.
+    if let Some(expected) = &step.checks.finalized_header {
+        assert!(
+            beacon_header_matches(expected, client.finalized_header()),
+            "step {}: finalized header mismatch (expected slot {})",
+            step_num,
+            expected.slot,
+        );
     }
-
-    if let Some(ref expected) = step.checks.optimistic_header {
-        if !beacon_header_matches(expected, client.optimistic_header()) {
-            println!(
-                "  FAIL: Optimistic header mismatch (expected slot {})",
-                expected.slot
-            );
-            step_passed = false;
-        }
+    if let Some(expected) = &step.checks.optimistic_header {
+        assert!(
+            beacon_header_matches(expected, client.optimistic_header()),
+            "step {}: optimistic header mismatch (expected slot {})",
+            step_num,
+            expected.slot,
+        );
     }
-
-    if step_passed {
-        println!("  PASS");
-    }
-
-    step_passed
 }

--- a/tests/light_client_sync.rs
+++ b/tests/light_client_sync.rs
@@ -13,17 +13,17 @@ use eth_light_client::test_utils::{
 use eth_light_client::{LightClient, UpdateOutcome};
 
 #[test]
-fn test_light_client_public_api_sync_altair() {
+fn altair_sync_via_public_api() {
     run_public_api_sync(SpecTestLoader::minimal_altair_sync());
 }
 
 #[test]
-fn test_light_client_public_api_sync_bellatrix() {
+fn bellatrix_sync_via_public_api() {
     run_public_api_sync(SpecTestLoader::minimal_bellatrix_sync());
 }
 
 #[test]
-fn test_light_client_public_api_sync_capella() {
+fn capella_sync_via_public_api() {
     run_public_api_sync(SpecTestLoader::minimal_capella_sync());
 }
 


### PR DESCRIPTION
Cleans up the light-client sync spec-test harnesses (no coverage change) and adds a consensus module README. Five commits:

- **reorder** — `light_client_spec_tests.rs` top-down (tests → driver → helpers).
- **assert-first** — both harnesses drop the print-and-count machinery (`StepResult`, counters, final `assert_eq!(failed,0)`) for direct `assert!`s carrying step/fork/value context. Failures now point at the exact mismatch instead of "1 step(s) failed".
- **name by surface** — `<fork>_sync_via_processor` (internal) / `<fork>_sync_via_public_api` (public API), drivers `run_processor_sync` / `run_public_api_sync`. Both are conformance replays, not unit tests, so named by surface rather than unit/integration.
- **consensus README** — module-level `README.md` wired via `include_str!`, scoped to the testing setup for now (scope × surface axes).
- **break on force_update** — replace `.take(5)` + a dead skip arm with `break` at the first `force_update` (unimplemented; later steps depend on its state transition). Adds a `processed > 0` guard.

All 76 unit + 3 integration tests pass; clippy clean in both feature modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)