### PR TITLE
refactor: test_utils audit — error types, module layout, naming

### DIFF
--- a/src/test_utils/README.md
+++ b/src/test_utils/README.md
@@ -63,7 +63,7 @@ sequenceDiagram
     R-->>L: header + sync committee
     L->>S: parse genesis root
     S-->>L: Root
-    L-->>T: BootstrapData
+    L-->>T: LightClientBootstrap
 
     T->>L: load_update(name)
     L->>R: decode + convert
@@ -71,8 +71,8 @@ sequenceDiagram
     L-->>T: LightClientUpdate
 ```
 
-The `test` then feeds the returned `BootstrapData` / `LightClientUpdate` into
-`LightClient::new` / `process_update` — the code actually under test.
+The `test` then feeds the returned `LightClientBootstrap` / `LightClientUpdate`
+into `LightClient::new` / `process_update` — the code actually under test.
 
 
 ## Usage
@@ -85,7 +85,7 @@ let loader = SpecTestLoader::minimal_altair_sync();
 
 let mut client = LightClient::new(
     loader.chain_spec(),
-    loader.load_bootstrap()?.into_bootstrap(),
+    loader.load_bootstrap()?,
 )?;
 
 for step in loader.load_steps()? {

--- a/src/test_utils/README.md
+++ b/src/test_utils/README.md
@@ -20,9 +20,9 @@ the light client against the official vectors with no network or beacon node.
 |------|----------------|
 | `loader.rs` | `SpecTestLoader` — the entry point; reads fixture files and returns typed objects |
 | `raw_ssz.rs` | `Raw*` SSZ structs + the `raw_*_to_pub` raw→production converters |
-| `steps.rs` | YAML fixture types (`meta.yaml` / `steps.yaml`) + `hex_to_root` |
+| `steps.rs` | YAML fixture types (`meta.yaml` / `steps.yaml`) + `beacon_header_matches` |
 | `fork.rs` | `MinimalPresetFork` — the minimal-preset fork tag and its `ChainSpec` |
-| `mod.rs` | module wiring / re-exports |
+| `mod.rs` | module wiring / re-exports + `hex_to_root` |
 
 ## Fixtures
 

--- a/src/test_utils/loader.rs
+++ b/src/test_utils/loader.rs
@@ -60,7 +60,7 @@ impl SpecTestLoader {
         match self.fork {
             MinimalPresetFork::Altair | MinimalPresetFork::Bellatrix => {
                 let bootstrap: RawLightClientBootstrap = load_ssz_snappy(&bootstrap_path)?;
-                let sync_committee = bootstrap.current_sync_committee.to_sync_committee()?;
+                let sync_committee = bootstrap.current_sync_committee.to_sync_committee();
                 let branch = nodes_to_roots(&bootstrap.current_sync_committee_branch);
                 let header = raw_beacon_only_header_to_pub(self.fork, bootstrap.header);
 
@@ -73,7 +73,7 @@ impl SpecTestLoader {
             }
             MinimalPresetFork::Capella => {
                 let bootstrap: RawCapellaLightClientBootstrap = load_ssz_snappy(&bootstrap_path)?;
-                let sync_committee = bootstrap.current_sync_committee.to_sync_committee()?;
+                let sync_committee = bootstrap.current_sync_committee.to_sync_committee();
                 let branch = nodes_to_roots(&bootstrap.current_sync_committee_branch);
                 let header = raw_capella_header_to_pub(bootstrap.header)?;
 
@@ -94,11 +94,11 @@ impl SpecTestLoader {
         match self.fork {
             MinimalPresetFork::Altair | MinimalPresetFork::Bellatrix => {
                 let raw: RawLightClientUpdate = load_ssz_snappy(&update_path)?;
-                raw_beacon_only_update_to_pub(self.fork, raw).map_err(|e| e.into())
+                Ok(raw_beacon_only_update_to_pub(self.fork, raw))
             }
             MinimalPresetFork::Capella => {
                 let raw: RawCapellaLightClientUpdate = load_ssz_snappy(&update_path)?;
-                raw_capella_update_to_pub(raw).map_err(|e| e.into())
+                raw_capella_update_to_pub(raw)
             }
         }
     }

--- a/src/test_utils/loader.rs
+++ b/src/test_utils/loader.rs
@@ -6,7 +6,7 @@ use super::raw_ssz::{
     RawCapellaLightClientUpdate, RawLightClientBootstrap, RawLightClientUpdate,
 };
 use super::steps::{TestMeta, TestStep};
-use super::{hex_to_root, MinimalPresetFork};
+use super::{hex_to_root, MinimalPresetFork, TestUtilsResult};
 use crate::types::consensus::{LightClientBootstrap, LightClientUpdate};
 use ssz_rs::prelude::*;
 use std::fs;
@@ -52,7 +52,7 @@ impl SpecTestLoader {
         self.fork.chain_spec()
     }
 
-    pub fn load_bootstrap(&self) -> Result<LightClientBootstrap, Box<dyn std::error::Error>> {
+    pub fn load_bootstrap(&self) -> TestUtilsResult<LightClientBootstrap> {
         let meta = self.load_meta()?;
         let genesis_validators_root = hex_to_root(&meta.genesis_validators_root)?;
         let bootstrap_path = self.test_dir.join("bootstrap.ssz_snappy");
@@ -88,7 +88,7 @@ impl SpecTestLoader {
     }
 
     /// `name` must not include the `.ssz_snappy` extension.
-    pub fn load_update(&self, name: &str) -> Result<LightClientUpdate, Box<dyn std::error::Error>> {
+    pub fn load_update(&self, name: &str) -> TestUtilsResult<LightClientUpdate> {
         let update_path = self.test_dir.join(format!("{}.ssz_snappy", name));
 
         match self.fork {
@@ -103,14 +103,14 @@ impl SpecTestLoader {
         }
     }
 
-    pub(crate) fn load_meta(&self) -> Result<TestMeta, Box<dyn std::error::Error>> {
+    pub(crate) fn load_meta(&self) -> TestUtilsResult<TestMeta> {
         let meta_path = self.test_dir.join("meta.yaml");
         let meta_contents = fs::read_to_string(&meta_path)?;
         let meta: TestMeta = serde_yaml::from_str(&meta_contents)?;
         Ok(meta)
     }
 
-    pub fn load_steps(&self) -> Result<Vec<TestStep>, Box<dyn std::error::Error>> {
+    pub fn load_steps(&self) -> TestUtilsResult<Vec<TestStep>> {
         let steps_path = self.test_dir.join("steps.yaml");
         let steps_contents = fs::read_to_string(&steps_path)?;
         let steps: Vec<TestStep> = serde_yaml::from_str(&steps_contents)?;
@@ -127,7 +127,7 @@ pub(crate) fn load_altair_bootstrap() -> LightClientBootstrap {
         .expect("Failed to load bootstrap")
 }
 
-fn load_ssz_snappy<T>(file_path: &Path) -> Result<T, Box<dyn std::error::Error>>
+fn load_ssz_snappy<T>(file_path: &Path) -> TestUtilsResult<T>
 where
     T: Deserialize,
 {

--- a/src/test_utils/loader.rs
+++ b/src/test_utils/loader.rs
@@ -60,7 +60,7 @@ impl SpecTestLoader {
         match self.fork {
             MinimalPresetFork::Altair | MinimalPresetFork::Bellatrix => {
                 let bootstrap: RawLightClientBootstrap = load_ssz_snappy(&bootstrap_path)?;
-                let sync_committee = bootstrap.current_sync_committee.to_sync_committee();
+                let sync_committee = bootstrap.current_sync_committee.into_sync_committee();
                 let branch = nodes_to_roots(&bootstrap.current_sync_committee_branch);
                 let header = raw_beacon_only_header_to_pub(self.fork, bootstrap.header);
 
@@ -73,7 +73,7 @@ impl SpecTestLoader {
             }
             MinimalPresetFork::Capella => {
                 let bootstrap: RawCapellaLightClientBootstrap = load_ssz_snappy(&bootstrap_path)?;
-                let sync_committee = bootstrap.current_sync_committee.to_sync_committee();
+                let sync_committee = bootstrap.current_sync_committee.into_sync_committee();
                 let branch = nodes_to_roots(&bootstrap.current_sync_committee_branch);
                 let header = raw_capella_header_to_pub(bootstrap.header)?;
 

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -19,12 +19,9 @@ pub(crate) type TestUtilsResult<T> = Result<T, Box<dyn std::error::Error>>;
 pub(crate) fn hex_to_root(hex: &str) -> TestUtilsResult<Root> {
     let hex = hex.strip_prefix("0x").unwrap_or(hex);
     let bytes = hex::decode(hex)?;
-    if bytes.len() != 32 {
-        return Err(format!("Expected 32 bytes, got {}", bytes.len()).into());
-    }
-    let mut root = [0u8; 32];
-    root.copy_from_slice(&bytes);
-    Ok(root)
+    bytes
+        .try_into()
+        .map_err(|b: Vec<u8>| format!("expected 32 bytes, got {}", b.len()).into())
 }
 
 #[cfg(test)]

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -5,14 +5,27 @@ mod loader;
 mod raw_ssz;
 mod steps;
 
+use crate::types::primitives::Root;
+
 pub use loader::SpecTestLoader;
 pub use steps::{beacon_header_matches, HeaderCheck, ProcessUpdateStep, StateChecks, TestStep};
 
 pub(crate) use fork::MinimalPresetFork;
-pub(crate) use steps::hex_to_root;
 
 /// Box<dyn Error>, not `crate::error::Result`: test glue stays decoupled from the production error enum.
 pub(crate) type TestUtilsResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+/// Convert a hex string (with or without 0x prefix) to a 32-byte root.
+pub(crate) fn hex_to_root(hex: &str) -> TestUtilsResult<Root> {
+    let hex = hex.strip_prefix("0x").unwrap_or(hex);
+    let bytes = hex::decode(hex)?;
+    if bytes.len() != 32 {
+        return Err(format!("Expected 32 bytes, got {}", bytes.len()).into());
+    }
+    let mut root = [0u8; 32];
+    root.copy_from_slice(&bytes);
+    Ok(root)
+}
 
 #[cfg(test)]
 pub(crate) use loader::load_altair_bootstrap;

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -11,5 +11,8 @@ pub use steps::{beacon_header_matches, HeaderCheck, ProcessUpdateStep, StateChec
 pub(crate) use fork::MinimalPresetFork;
 pub(crate) use steps::hex_to_root;
 
+/// Box<dyn Error>, not `crate::error::Result`: test glue stays decoupled from the production error enum.
+pub(crate) type TestUtilsResult<T> = Result<T, Box<dyn std::error::Error>>;
+
 #[cfg(test)]
 pub(crate) use loader::load_altair_bootstrap;

--- a/src/test_utils/raw_ssz.rs
+++ b/src/test_utils/raw_ssz.rs
@@ -48,7 +48,7 @@ pub(crate) struct RawSyncCommittee {
 }
 
 impl RawSyncCommittee {
-    pub(crate) fn to_sync_committee(&self) -> SyncCommittee {
+    pub(crate) fn into_sync_committee(self) -> SyncCommittee {
         // Minimal fixtures hold 32 pubkeys; production is mainnet-sized (512).
         // Padding is inert: root + signature checks read only pubkeys[..N] (N from ChainSpec).
         // The 32-element count is guaranteed by the SSZ `Vector<_, 32>` decode.
@@ -264,7 +264,7 @@ pub(crate) fn raw_beacon_only_update_to_pub(
     fork: MinimalPresetFork,
     raw: RawLightClientUpdate,
 ) -> LightClientUpdate {
-    let sync_committee = raw.next_sync_committee.to_sync_committee();
+    let sync_committee = raw.next_sync_committee.into_sync_committee();
     let sync_aggregate = raw.sync_aggregate.into_sync_aggregate();
     let finality_branch = nodes_to_roots(&raw.finality_branch);
     let next_sync_committee_branch = nodes_to_roots(&raw.next_sync_committee_branch);
@@ -291,7 +291,7 @@ pub(crate) fn raw_beacon_only_update_to_pub(
 pub(crate) fn raw_capella_update_to_pub(
     raw: RawCapellaLightClientUpdate,
 ) -> TestUtilsResult<LightClientUpdate> {
-    let sync_committee = raw.next_sync_committee.to_sync_committee();
+    let sync_committee = raw.next_sync_committee.into_sync_committee();
     let sync_aggregate = raw.sync_aggregate.into_sync_aggregate();
     let finality_branch = nodes_to_roots(&raw.finality_branch);
     let next_sync_committee_branch = nodes_to_roots(&raw.next_sync_committee_branch);

--- a/src/test_utils/raw_ssz.rs
+++ b/src/test_utils/raw_ssz.rs
@@ -48,16 +48,10 @@ pub(crate) struct RawSyncCommittee {
 }
 
 impl RawSyncCommittee {
-    pub(crate) fn to_sync_committee(&self) -> Result<SyncCommittee, String> {
-        if self.pubkeys.len() != 32 {
-            return Err(format!(
-                "Expected 32 pubkeys (minimal preset), got {}",
-                self.pubkeys.len()
-            ));
-        }
-
+    pub(crate) fn to_sync_committee(&self) -> SyncCommittee {
         // Minimal fixtures hold 32 pubkeys; production is mainnet-sized (512).
         // Padding is inert: root + signature checks read only pubkeys[..N] (N from ChainSpec).
+        // The 32-element count is guaranteed by the SSZ `Vector<_, 32>` decode.
         let mut pubkeys_array = Box::new([[0u8; 48]; 512]);
         for (i, pk) in self.pubkeys.iter().enumerate() {
             let mut key = [0u8; 48];
@@ -68,7 +62,7 @@ impl RawSyncCommittee {
         let mut aggregate = [0u8; 48];
         aggregate.copy_from_slice(self.aggregate_pubkey.as_ref());
 
-        Ok(SyncCommittee::new(pubkeys_array, aggregate))
+        SyncCommittee::new(pubkeys_array, aggregate)
     }
 }
 
@@ -79,7 +73,7 @@ struct RawSyncAggregate {
 }
 
 impl RawSyncAggregate {
-    fn into_sync_aggregate(self) -> Result<SyncAggregate, String> {
+    fn into_sync_aggregate(self) -> SyncAggregate {
         let mut bits_array = Box::new([false; 512]);
         for (i, bit) in self.sync_committee_bits.iter().enumerate() {
             bits_array[i] = *bit;
@@ -88,7 +82,7 @@ impl RawSyncAggregate {
         let mut signature = [0u8; 96];
         signature.copy_from_slice(self.sync_committee_signature.as_ref());
 
-        Ok(SyncAggregate::new(bits_array, signature))
+        SyncAggregate::new(bits_array, signature)
     }
 }
 
@@ -124,7 +118,9 @@ struct RawExecutionPayloadHeader {
 }
 
 impl RawExecutionPayloadHeader {
-    fn into_execution_payload_header(self) -> Result<ExecutionPayloadHeaderCapella, String> {
+    fn into_execution_payload_header(
+        self,
+    ) -> Result<ExecutionPayloadHeaderCapella, Box<dyn std::error::Error>> {
         let mut fee_recipient = [0u8; 20];
         fee_recipient.copy_from_slice(self.fee_recipient.as_ref());
 
@@ -139,7 +135,7 @@ impl RawExecutionPayloadHeader {
         let base_fee = ruint::aliases::U256::from_le_bytes(u256_bytes);
 
         let extra_data_vec: Vec<u8> = self.extra_data.to_vec();
-        let extra_data = ExtraData::try_new(extra_data_vec).map_err(|e| e.to_string())?;
+        let extra_data = ExtraData::try_new(extra_data_vec)?;
 
         Ok(ExecutionPayloadHeaderCapella {
             parent_hash: node_to_root(&self.parent_hash),
@@ -202,7 +198,7 @@ pub(crate) fn raw_beacon_only_header_to_pub(
 
 pub(crate) fn raw_capella_header_to_pub(
     raw: RawCapellaLightClientHeader,
-) -> Result<LightClientHeader, String> {
+) -> Result<LightClientHeader, Box<dyn std::error::Error>> {
     let beacon = raw.beacon.into_beacon_block_header();
     let execution = raw.execution.into_execution_payload_header()?;
     let mut execution_branch = [[0u8; 32]; 4];
@@ -269,9 +265,9 @@ fn assemble_update(
 pub(crate) fn raw_beacon_only_update_to_pub(
     fork: MinimalPresetFork,
     raw: RawLightClientUpdate,
-) -> Result<LightClientUpdate, String> {
-    let sync_committee = raw.next_sync_committee.to_sync_committee()?;
-    let sync_aggregate = raw.sync_aggregate.into_sync_aggregate()?;
+) -> LightClientUpdate {
+    let sync_committee = raw.next_sync_committee.to_sync_committee();
+    let sync_aggregate = raw.sync_aggregate.into_sync_aggregate();
     let finality_branch = nodes_to_roots(&raw.finality_branch);
     let next_sync_committee_branch = nodes_to_roots(&raw.next_sync_committee_branch);
 
@@ -283,7 +279,7 @@ pub(crate) fn raw_beacon_only_update_to_pub(
     };
     let attested_header = raw_beacon_only_header_to_pub(fork, raw.attested_header);
 
-    Ok(assemble_update(
+    assemble_update(
         attested_header,
         finalized_header,
         finality_branch,
@@ -291,14 +287,14 @@ pub(crate) fn raw_beacon_only_update_to_pub(
         next_sync_committee_branch,
         sync_aggregate,
         raw.signature_slot,
-    ))
+    )
 }
 
 pub(crate) fn raw_capella_update_to_pub(
     raw: RawCapellaLightClientUpdate,
-) -> Result<LightClientUpdate, String> {
-    let sync_committee = raw.next_sync_committee.to_sync_committee()?;
-    let sync_aggregate = raw.sync_aggregate.into_sync_aggregate()?;
+) -> Result<LightClientUpdate, Box<dyn std::error::Error>> {
+    let sync_committee = raw.next_sync_committee.to_sync_committee();
+    let sync_aggregate = raw.sync_aggregate.into_sync_aggregate();
     let finality_branch = nodes_to_roots(&raw.finality_branch);
     let next_sync_committee_branch = nodes_to_roots(&raw.next_sync_committee_branch);
 

--- a/src/test_utils/raw_ssz.rs
+++ b/src/test_utils/raw_ssz.rs
@@ -1,6 +1,6 @@
 //! Raw SSZ fixture types and their conversions into production light client types.
 
-use super::MinimalPresetFork;
+use super::{MinimalPresetFork, TestUtilsResult};
 use crate::types::consensus::{
     BeaconBlockHeader, ExecutionPayloadHeaderCapella, LightClientHeader, LightClientUpdate,
     SyncAggregate, SyncCommittee,
@@ -118,9 +118,7 @@ struct RawExecutionPayloadHeader {
 }
 
 impl RawExecutionPayloadHeader {
-    fn into_execution_payload_header(
-        self,
-    ) -> Result<ExecutionPayloadHeaderCapella, Box<dyn std::error::Error>> {
+    fn into_execution_payload_header(self) -> TestUtilsResult<ExecutionPayloadHeaderCapella> {
         let mut fee_recipient = [0u8; 20];
         fee_recipient.copy_from_slice(self.fee_recipient.as_ref());
 
@@ -198,7 +196,7 @@ pub(crate) fn raw_beacon_only_header_to_pub(
 
 pub(crate) fn raw_capella_header_to_pub(
     raw: RawCapellaLightClientHeader,
-) -> Result<LightClientHeader, Box<dyn std::error::Error>> {
+) -> TestUtilsResult<LightClientHeader> {
     let beacon = raw.beacon.into_beacon_block_header();
     let execution = raw.execution.into_execution_payload_header()?;
     let mut execution_branch = [[0u8; 32]; 4];
@@ -292,7 +290,7 @@ pub(crate) fn raw_beacon_only_update_to_pub(
 
 pub(crate) fn raw_capella_update_to_pub(
     raw: RawCapellaLightClientUpdate,
-) -> Result<LightClientUpdate, Box<dyn std::error::Error>> {
+) -> TestUtilsResult<LightClientUpdate> {
     let sync_committee = raw.next_sync_committee.to_sync_committee();
     let sync_aggregate = raw.sync_aggregate.into_sync_aggregate();
     let finality_branch = nodes_to_roots(&raw.finality_branch);

--- a/src/test_utils/raw_ssz.rs
+++ b/src/test_utils/raw_ssz.rs
@@ -56,6 +56,8 @@ impl RawSyncCommittee {
             ));
         }
 
+        // Minimal fixtures hold 32 pubkeys; production is mainnet-sized (512).
+        // Padding is inert: root + signature checks read only pubkeys[..N] (N from ChainSpec).
         let mut pubkeys_array = Box::new([[0u8; 48]; 512]);
         for (i, pk) in self.pubkeys.iter().enumerate() {
             let mut key = [0u8; 48];
@@ -214,7 +216,6 @@ pub(crate) fn raw_capella_header_to_pub(
     ))
 }
 
-/// Convert a branch of SSZ nodes into `Root`s.
 /// Copy a 32-byte SSZ node into a `Root`.
 fn node_to_root(node: &Node) -> Root {
     let mut root = [0u8; 32];
@@ -222,6 +223,7 @@ fn node_to_root(node: &Node) -> Root {
     root
 }
 
+/// Convert a branch of SSZ nodes into `Root`s.
 pub(crate) fn nodes_to_roots(nodes: &[Node]) -> Vec<Root> {
     nodes.iter().map(node_to_root).collect()
 }

--- a/src/test_utils/steps.rs
+++ b/src/test_utils/steps.rs
@@ -1,5 +1,6 @@
 //! YAML metadata and step types deserialized from spec test fixtures.
 
+use super::TestUtilsResult;
 use crate::types::consensus::BeaconBlockHeader;
 use crate::types::primitives::Root;
 
@@ -47,7 +48,7 @@ pub struct ProcessUpdateStep {
 }
 
 /// Convert a hex string (with or without 0x prefix) to a 32-byte root.
-pub(crate) fn hex_to_root(hex: &str) -> Result<Root, Box<dyn std::error::Error>> {
+pub(crate) fn hex_to_root(hex: &str) -> TestUtilsResult<Root> {
     let hex = hex.strip_prefix("0x").unwrap_or(hex);
     let bytes = hex::decode(hex)?;
     if bytes.len() != 32 {

--- a/src/test_utils/steps.rs
+++ b/src/test_utils/steps.rs
@@ -1,8 +1,7 @@
 //! YAML metadata and step types deserialized from spec test fixtures.
 
-use super::TestUtilsResult;
+use super::hex_to_root;
 use crate::types::consensus::BeaconBlockHeader;
-use crate::types::primitives::Root;
 
 /// Metadata from a spec test's meta.yaml file.
 ///
@@ -45,18 +44,6 @@ pub struct ProcessUpdateStep {
     pub update: String,
     pub current_slot: u64,
     pub checks: StateChecks,
-}
-
-/// Convert a hex string (with or without 0x prefix) to a 32-byte root.
-pub(crate) fn hex_to_root(hex: &str) -> TestUtilsResult<Root> {
-    let hex = hex.strip_prefix("0x").unwrap_or(hex);
-    let bytes = hex::decode(hex)?;
-    if bytes.len() != 32 {
-        return Err(format!("Expected 32 bytes, got {}", bytes.len()).into());
-    }
-    let mut root = [0u8; 32];
-    root.copy_from_slice(&bytes);
-    Ok(root)
 }
 
 /// Whether a beacon header matches a fixture `HeaderCheck` (slot + beacon root).

--- a/src/test_utils/steps.rs
+++ b/src/test_utils/steps.rs
@@ -40,8 +40,6 @@ pub enum TestStep {
 
 #[derive(Debug, serde::Deserialize)]
 pub struct ProcessUpdateStep {
-    #[allow(dead_code)]
-    update_fork_digest: String,
     /// Update file name (without .ssz_snappy extension).
     pub update: String,
     pub current_slot: u64,


### PR DESCRIPTION
Continues the `test_utils` audit. Test-only glue; no public API or behavior change (the module is `test-utils`-gated). Each commit is self-contained.

## Commits
- **clean-wins** — fixed crossed `node_to_root`/`nodes_to_roots` doc comments, deleted the dead `ProcessUpdateStep.update_fork_digest` field, corrected stale `README.md` references (post-`BootstrapData` collapse), documented why the 32→512 sync-committee pad is safe.
- **error types** — the conversion layer spoke three error dialects (`String`, `Box<dyn Error>`, `crate::error::Error` stringified on arrival). Unified on `Box<dyn Error>` and dropped `Result` from the signatures that never invoke a fallible call (`to_sync_committee`/`into_sync_aggregate` → infallible; `raw_beacon_only_update_to_pub` infallible by cascade). The rule: return `Result` iff you *invoke* something that returns `Result`.
- **`TestUtilsResult` alias** — collapses the ~9 `Result<_, Box<dyn Error>>` sites behind one module-scoped alias. Named distinctly so it never shadows the crate's own `error::Result` (which wraps the `thiserror` enum); the two stay decoupled on purpose.
- **`hex_to_root` → `mod.rs`** — it's a generic hex→`Root` primitive, not a step/YAML type; the old `pub(crate) use steps::hex_to_root` re-export was the tell. Also tightened its body via stdlib `TryFrom<Vec<u8>> for [u8; 32]`.
- **`into_sync_committee`** — renamed from `to_sync_committee` and made it consume `self`, matching `into_sync_aggregate` (Rust convention: `to_` borrows, `into_` consumes; nothing reuses the raw after the call).

## Testing
`cargo test` and `cargo test --features test-utils` both green (76 unit + 3 integration + doc tests).

## Out of scope
- Fixture-hash-pinned regression test in `raw_ssz.rs` (`no_finality_update_yields_none_finalized_header`) — tracked for a follow-up.
- Pre-existing `--all-targets` clippy warnings in `types/consensus.rs` / `consensus/light_client.rs` — untouched parked (#56) files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)