### PR TITLE
refactor: test_utils audit round 2 — minimal-config single-sourcing, drift guard, LightClientSyncTest rename

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -162,6 +162,27 @@ pub struct ChainSpecConfig {
 }
 
 impl ChainSpecConfig {
+    /// Single source of truth for the minimal preset (spec-test config).
+    pub const fn minimal() -> Self {
+        Self {
+            genesis_time: 1578009600,
+            seconds_per_slot: 6,
+            slots_per_epoch: 8,
+            epochs_per_sync_committee_period: 8,
+            sync_committee_size: 32,
+            altair_fork_version: [0x01, 0x00, 0x00, 0x01],
+            bellatrix_fork_version: [0x02, 0x00, 0x00, 0x01],
+            capella_fork_version: [0x03, 0x00, 0x00, 0x01],
+            deneb_fork_version: [0x04, 0x00, 0x00, 0x01],
+            electra_fork_version: [0x05, 0x00, 0x00, 0x01],
+            altair_fork_epoch: 0,
+            bellatrix_fork_epoch: u64::MAX,
+            capella_fork_epoch: u64::MAX,
+            deneb_fork_epoch: u64::MAX,
+            electra_fork_epoch: u64::MAX,
+        }
+    }
+
     /// Validate the configuration.
     ///
     /// Returns an error if any values are invalid or inconsistent.
@@ -257,23 +278,9 @@ impl ChainSpec {
         }
     }
 
-    /// Minimal test specification
+    /// Minimal test spec, from [`ChainSpecConfig::minimal`].
     pub const fn minimal() -> Self {
-        Self {
-            preset_name: "minimal",
-            genesis_time: 1578009600,
-            seconds_per_slot: 6,
-            slots_per_epoch: 8,
-            epochs_per_sync_committee_period: 8,
-            sync_committee_size: 32,
-            fork_schedule: ForkSchedule::new(
-                ForkParams::new([0x01, 0x00, 0x00, 0x01], 0),
-                ForkParams::new([0x02, 0x00, 0x00, 0x01], u64::MAX),
-                ForkParams::new([0x03, 0x00, 0x00, 0x01], u64::MAX),
-                ForkParams::new([0x04, 0x00, 0x00, 0x01], u64::MAX),
-                ForkParams::new([0x05, 0x00, 0x00, 0x01], u64::MAX),
-            ),
-        }
+        Self::from_config(ChainSpecConfig::minimal(), "minimal")
     }
 
     /// Create a ChainSpec from a custom configuration.
@@ -282,9 +289,13 @@ impl ChainSpec {
     /// The configuration is validated before the ChainSpec is created.
     pub fn try_from_config(config: ChainSpecConfig) -> Result<Self> {
         config.validate()?;
+        Ok(Self::from_config(config, "custom"))
+    }
 
-        Ok(Self {
-            preset_name: "custom",
+    /// The one place the config -> spec mapping lives; callers own validation.
+    const fn from_config(config: ChainSpecConfig, preset_name: &'static str) -> Self {
+        Self {
+            preset_name,
             genesis_time: config.genesis_time,
             seconds_per_slot: config.seconds_per_slot,
             slots_per_epoch: config.slots_per_epoch,
@@ -297,7 +308,7 @@ impl ChainSpec {
                 ForkParams::new(config.deneb_fork_version, config.deneb_fork_epoch),
                 ForkParams::new(config.electra_fork_version, config.electra_fork_epoch),
             ),
-        })
+        }
     }
 
     /// Test constructor for creating custom specs (e.g., fork boundary tests).

--- a/src/consensus/light_client_spec_tests.rs
+++ b/src/consensus/light_client_spec_tests.rs
@@ -10,36 +10,36 @@
 
 use crate::consensus::light_client::LightClientProcessor;
 use crate::test_utils::{
-    beacon_header_matches, hex_to_root, ProcessUpdateStep, SpecTestLoader, TestStep,
+    beacon_header_matches, hex_to_root, LightClientSyncTest, ProcessUpdateStep, TestStep,
 };
 use crate::types::consensus::LightClientHeader;
 
 #[test]
 fn altair_sync_via_processor() {
-    run_processor_sync(SpecTestLoader::minimal_altair_sync());
+    run_processor_sync(LightClientSyncTest::minimal_altair());
 }
 
 #[test]
 fn bellatrix_sync_via_processor() {
-    run_processor_sync(SpecTestLoader::minimal_bellatrix_sync());
+    run_processor_sync(LightClientSyncTest::minimal_bellatrix());
 }
 
 /// Capella additionally verifies execution roots.
 #[test]
 fn capella_sync_via_processor() {
-    run_processor_sync(SpecTestLoader::minimal_capella_sync());
+    run_processor_sync(LightClientSyncTest::minimal_capella());
 }
 
 /// Replay a fork's `process_update` steps, asserting each against the fixture.
-fn run_processor_sync(loader: SpecTestLoader) {
-    let steps = loader.load_steps().expect("Failed to load steps");
-    let mut processor = initialize_processor_from(&loader);
+fn run_processor_sync(sync_test: LightClientSyncTest) {
+    let steps = sync_test.load_steps().expect("Failed to load steps");
+    let mut processor = initialize_processor_from(&sync_test);
 
     let mut processed = 0;
     for (i, step) in steps.iter().enumerate() {
         match step {
             TestStep::ProcessUpdate { process_update } => {
-                execute_process_update_step(i + 1, process_update, &mut processor, &loader);
+                execute_process_update_step(i + 1, process_update, &mut processor, &sync_test);
                 processed += 1;
             }
             // later steps depend on force_update's transition -- stop, don't skip
@@ -52,9 +52,11 @@ fn run_processor_sync(loader: SpecTestLoader) {
     );
 }
 
-fn initialize_processor_from(loader: &SpecTestLoader) -> LightClientProcessor {
-    let bootstrap = loader.load_bootstrap().expect("Failed to load bootstrap");
-    let chain_spec = loader.chain_spec();
+fn initialize_processor_from(sync_test: &LightClientSyncTest) -> LightClientProcessor {
+    let bootstrap = sync_test
+        .load_bootstrap()
+        .expect("Failed to load bootstrap");
+    let chain_spec = sync_test.chain_spec();
 
     LightClientProcessor::new(
         chain_spec,
@@ -70,9 +72,9 @@ fn execute_process_update_step(
     step_num: usize,
     step: &ProcessUpdateStep,
     processor: &mut LightClientProcessor,
-    loader: &SpecTestLoader,
+    sync_test: &LightClientSyncTest,
 ) {
-    let update = loader.load_update(&step.update).unwrap_or_else(|e| {
+    let update = sync_test.load_update(&step.update).unwrap_or_else(|e| {
         panic!(
             "step {}: failed to load update {}: {}",
             step_num, step.update, e

--- a/src/consensus/merkle.rs
+++ b/src/consensus/merkle.rs
@@ -429,11 +429,13 @@ mod tests {
     /// Uses the minimal preset test vectors.
     #[test]
     fn test_sync_committee_root_against_spec_fixture() {
-        use crate::test_utils::SpecTestLoader;
+        use crate::test_utils::LightClientSyncTest;
 
         let spec = ChainSpec::minimal();
-        let loader = SpecTestLoader::minimal_altair_sync();
-        let bootstrap = loader.load_bootstrap().expect("Failed to load bootstrap");
+        let sync_test = LightClientSyncTest::minimal_altair();
+        let bootstrap = sync_test
+            .load_bootstrap()
+            .expect("Failed to load bootstrap");
 
         // Compute sync committee root using our hardened function
         let computed_root = compute_sync_committee_root(&spec, &bootstrap.current_sync_committee);

--- a/src/test_utils/README.md
+++ b/src/test_utils/README.md
@@ -20,9 +20,9 @@ the light client against the official vectors with no network or beacon node.
 |------|----------------|
 | `loader.rs` | `SpecTestLoader` — the entry point; reads fixture files and returns typed objects |
 | `raw_ssz.rs` | `Raw*` SSZ structs + the `raw_*_to_pub` raw→production converters |
-| `steps.rs` | YAML fixture types (`meta.yaml` / `steps.yaml`) + `beacon_header_matches` |
+| `steps.rs` | YAML fixture types (`meta.yaml` / `steps.yaml`) + the `hex_to_root` / `beacon_header_matches` fixture helpers |
 | `fork.rs` | `MinimalPresetFork` — the minimal-preset fork tag and its `ChainSpec` |
-| `mod.rs` | module wiring / re-exports + `hex_to_root` |
+| `mod.rs` | module wiring / re-exports |
 
 ## Fixtures
 

--- a/src/test_utils/README.md
+++ b/src/test_utils/README.md
@@ -18,7 +18,7 @@ the light client against the official vectors with no network or beacon node.
 
 | File | Responsibility |
 |------|----------------|
-| `loader.rs` | `SpecTestLoader` — the entry point; reads fixture files and returns typed objects |
+| `loader.rs` | `LightClientSyncTest` — the entry point; reads fixture files and returns typed objects |
 | `raw_ssz.rs` | `Raw*` SSZ structs + the `raw_*_to_pub` raw→production converters |
 | `steps.rs` | YAML fixture types (`meta.yaml` / `steps.yaml`) + the `hex_to_root` / `beacon_header_matches` fixture helpers |
 | `fork.rs` | `MinimalPresetFork` — the minimal-preset fork tag and its `ChainSpec` |
@@ -40,7 +40,7 @@ scripts the test:
 
 ## Data flow
 
-`SpecTestLoader` is only the **orchestrator**: it picks a file, decodes it into
+`LightClientSyncTest` is only the **orchestrator**: it picks a file, decodes it into
 a `Raw*` struct, calls the `raw_ssz` converters to produce the production type,
 and assembles the result. The two hops live in two places — decoding in the
 loader, converting in `raw_ssz`.
@@ -78,18 +78,18 @@ into `LightClient::new` / `process_update` — the code actually under test.
 ## Usage
 
 ```rust,ignore
-use eth_light_client::test_utils::SpecTestLoader;
+use eth_light_client::test_utils::LightClientSyncTest;
 use eth_light_client::{ChainSpec, LightClient};
 
-let loader = SpecTestLoader::minimal_altair_sync();
+let sync_test = LightClientSyncTest::minimal_altair();
 
 let mut client = LightClient::new(
-    loader.chain_spec(),
-    loader.load_bootstrap()?,
+    sync_test.chain_spec(),
+    sync_test.load_bootstrap()?,
 )?;
 
-for step in loader.load_steps()? {
-    // feed loader.load_update(&step.update) into client,
+for step in sync_test.load_steps()? {
+    // feed sync_test.load_update(&step.update) into client,
     // then compare client's headers against step.checks
 }
 ```

--- a/src/test_utils/fork.rs
+++ b/src/test_utils/fork.rs
@@ -14,28 +14,17 @@ impl MinimalPresetFork {
     /// Return a `ChainSpec` whose fork schedule matches the spec-test fixtures
     /// for this fork.
     pub(crate) fn chain_spec(&self) -> crate::config::ChainSpec {
-        use crate::config::{ChainSpec, ChainSpecConfig};
+        crate::config::ChainSpec::try_from_config(self.config())
+            .expect("minimal fixture config is valid")
+    }
 
-        let mut config = ChainSpecConfig {
-            genesis_time: 1578009600,
-            seconds_per_slot: 6,
-            slots_per_epoch: 8,
-            epochs_per_sync_committee_period: 8,
-            sync_committee_size: 32,
-            altair_fork_version: [0x01, 0x00, 0x00, 0x01],
-            altair_fork_epoch: 0,
-            bellatrix_fork_version: [0x02, 0x00, 0x00, 0x01],
-            bellatrix_fork_epoch: u64::MAX,
-            capella_fork_version: [0x03, 0x00, 0x00, 0x01],
-            capella_fork_epoch: u64::MAX,
-            deneb_fork_version: [0x04, 0x00, 0x00, 0x01],
-            deneb_fork_epoch: u64::MAX,
-            electra_fork_version: [0x05, 0x00, 0x00, 0x01],
-            electra_fork_epoch: u64::MAX,
-        };
+    /// [`ChainSpecConfig::minimal`] with the fork-activation epochs overridden
+    /// per fork — which forks are active, i.e. which signing-domain version applies.
+    fn config(&self) -> crate::config::ChainSpecConfig {
+        let mut config = crate::config::ChainSpecConfig::minimal();
 
         match self {
-            MinimalPresetFork::Altair => {} // defaults are correct
+            MinimalPresetFork::Altair => {} // later forks stay inactive (MAX)
             MinimalPresetFork::Bellatrix => {
                 config.bellatrix_fork_epoch = 0;
             }
@@ -45,6 +34,6 @@ impl MinimalPresetFork {
             }
         }
 
-        ChainSpec::try_from_config(config).expect("minimal fixture config is valid")
+        config
     }
 }

--- a/src/test_utils/fork.rs
+++ b/src/test_utils/fork.rs
@@ -37,3 +37,110 @@ impl MinimalPresetFork {
         config
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::MinimalPresetFork;
+    use std::path::Path;
+
+    /// Config.yaml keys we check. `Option` since earlier forks omit later-fork
+    /// keys; versions are hex strings under YAML 1.2.
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+    struct ConfigYaml {
+        preset_base: String,
+        seconds_per_slot: u64,
+        altair_fork_version: Option<String>,
+        altair_fork_epoch: Option<u64>,
+        bellatrix_fork_version: Option<String>,
+        bellatrix_fork_epoch: Option<u64>,
+        capella_fork_version: Option<String>,
+        capella_fork_epoch: Option<u64>,
+    }
+
+    fn load_config_yaml(fork: MinimalPresetFork) -> ConfigYaml {
+        let dir = match fork {
+            MinimalPresetFork::Altair => "altair",
+            MinimalPresetFork::Bellatrix => "bellatrix",
+            MinimalPresetFork::Capella => "capella",
+        };
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(format!(
+            "tests/fixtures/minimal/{dir}/light_client/sync/light_client_sync/config.yaml"
+        ));
+        let contents = std::fs::read_to_string(&path).expect("read config.yaml");
+        serde_yaml::from_str(&contents).expect("parse config.yaml")
+    }
+
+    fn version_bytes(hex: &str) -> [u8; 4] {
+        let h = hex.strip_prefix("0x").unwrap_or(hex);
+        hex::decode(h)
+            .expect("fork version hex")
+            .try_into()
+            .expect("fork version is 4 bytes")
+    }
+
+    /// Guards the hardcoded minimal schedule against drift from the fixtures.
+    /// config.yaml holds only the config half; the preset half isn't vendored,
+    /// so for that we assert only `PRESET_BASE == minimal`.
+    #[test]
+    fn hardcoded_schedule_matches_vendored_config_yaml() {
+        for fork in [
+            MinimalPresetFork::Altair,
+            MinimalPresetFork::Bellatrix,
+            MinimalPresetFork::Capella,
+        ] {
+            let cfg = fork.config();
+            let yaml = load_config_yaml(fork);
+
+            assert_eq!(yaml.preset_base, "minimal", "{:?}: PRESET_BASE", fork);
+            assert_eq!(
+                yaml.seconds_per_slot, cfg.seconds_per_slot,
+                "{:?}: SECONDS_PER_SLOT",
+                fork
+            );
+
+            // Assert whichever fork keys this fork's config.yaml actually provides.
+            let check_v = |field: &str, y: &Option<String>, hardcoded: [u8; 4]| {
+                if let Some(v) = y {
+                    assert_eq!(version_bytes(v), hardcoded, "{:?}: {}", fork, field);
+                }
+            };
+            let check_e = |field: &str, y: Option<u64>, hardcoded: u64| {
+                if let Some(e) = y {
+                    assert_eq!(e, hardcoded, "{:?}: {}", fork, field);
+                }
+            };
+
+            check_v(
+                "ALTAIR_FORK_VERSION",
+                &yaml.altair_fork_version,
+                cfg.altair_fork_version,
+            );
+            check_e(
+                "ALTAIR_FORK_EPOCH",
+                yaml.altair_fork_epoch,
+                cfg.altair_fork_epoch,
+            );
+            check_v(
+                "BELLATRIX_FORK_VERSION",
+                &yaml.bellatrix_fork_version,
+                cfg.bellatrix_fork_version,
+            );
+            check_e(
+                "BELLATRIX_FORK_EPOCH",
+                yaml.bellatrix_fork_epoch,
+                cfg.bellatrix_fork_epoch,
+            );
+            check_v(
+                "CAPELLA_FORK_VERSION",
+                &yaml.capella_fork_version,
+                cfg.capella_fork_version,
+            );
+            check_e(
+                "CAPELLA_FORK_EPOCH",
+                yaml.capella_fork_epoch,
+                cfg.capella_fork_epoch,
+            );
+        }
+    }
+}

--- a/src/test_utils/loader.rs
+++ b/src/test_utils/loader.rs
@@ -12,16 +12,17 @@ use ssz_rs::prelude::*;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-/// Loads spec test fixtures from a directory.
+/// One fork's minimal light-client-sync spec test: its `ChainSpec` plus the
+/// bootstrap / updates / steps loaded from the fixture directory.
 ///
 /// **Unstable:** This API may change without notice.
-pub struct SpecTestLoader {
+pub struct LightClientSyncTest {
     test_dir: PathBuf,
     fork: MinimalPresetFork,
 }
 
-impl SpecTestLoader {
-    pub fn minimal_altair_sync() -> Self {
+impl LightClientSyncTest {
+    pub fn minimal_altair() -> Self {
         let test_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("tests/fixtures/minimal/altair/light_client/sync/light_client_sync");
         Self {
@@ -30,7 +31,7 @@ impl SpecTestLoader {
         }
     }
 
-    pub fn minimal_bellatrix_sync() -> Self {
+    pub fn minimal_bellatrix() -> Self {
         let test_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("tests/fixtures/minimal/bellatrix/light_client/sync/light_client_sync");
         Self {
@@ -39,7 +40,7 @@ impl SpecTestLoader {
         }
     }
 
-    pub fn minimal_capella_sync() -> Self {
+    pub fn minimal_capella() -> Self {
         let test_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("tests/fixtures/minimal/capella/light_client/sync/light_client_sync");
         Self {
@@ -122,7 +123,7 @@ impl SpecTestLoader {
 /// valid bootstrap for setup.
 #[cfg(test)]
 pub(crate) fn load_altair_bootstrap() -> LightClientBootstrap {
-    SpecTestLoader::minimal_altair_sync()
+    LightClientSyncTest::minimal_altair()
         .load_bootstrap()
         .expect("Failed to load bootstrap")
 }

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -5,7 +5,7 @@ mod loader;
 mod raw_ssz;
 mod steps;
 
-pub use loader::SpecTestLoader;
+pub use loader::LightClientSyncTest;
 pub use steps::{beacon_header_matches, HeaderCheck, ProcessUpdateStep, StateChecks, TestStep};
 
 pub(crate) use fork::MinimalPresetFork;

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -5,24 +5,14 @@ mod loader;
 mod raw_ssz;
 mod steps;
 
-use crate::types::primitives::Root;
-
 pub use loader::SpecTestLoader;
 pub use steps::{beacon_header_matches, HeaderCheck, ProcessUpdateStep, StateChecks, TestStep};
 
 pub(crate) use fork::MinimalPresetFork;
+pub(crate) use steps::hex_to_root;
 
 /// Box<dyn Error>, not `crate::error::Result`: test glue stays decoupled from the production error enum.
 pub(crate) type TestUtilsResult<T> = Result<T, Box<dyn std::error::Error>>;
-
-/// Convert a hex string (with or without 0x prefix) to a 32-byte root.
-pub(crate) fn hex_to_root(hex: &str) -> TestUtilsResult<Root> {
-    let hex = hex.strip_prefix("0x").unwrap_or(hex);
-    let bytes = hex::decode(hex)?;
-    bytes
-        .try_into()
-        .map_err(|b: Vec<u8>| format!("expected 32 bytes, got {}", b.len()).into())
-}
 
 #[cfg(test)]
 pub(crate) use loader::load_altair_bootstrap;

--- a/src/test_utils/raw_ssz.rs
+++ b/src/test_utils/raw_ssz.rs
@@ -314,31 +314,3 @@ pub(crate) fn raw_capella_update_to_pub(
         raw.signature_slot,
     ))
 }
-
-#[cfg(test)]
-mod tests {
-    use crate::test_utils::SpecTestLoader;
-
-    // Regression guard against the beacon-only vs Capella converters drifting on
-    // finality handling: a no-finality update (spec `_sx`/`_xx` fixtures) must
-    // convert to `finalized_header: None`, not a `Some(slot-0 placeholder)`.
-    #[test]
-    fn no_finality_update_yields_none_finalized_header() {
-        let loader = SpecTestLoader::minimal_altair_sync();
-        // Altair step 4: a sync-committee update carrying no finality (`_sx`).
-        let update = loader
-            .load_update(
-                "update_0xa955d1485f6a3bb6c993c2699b16af66dc6ddf6f93a63d7cbe53334ad68c6e04_sx",
-            )
-            .expect("load no-finality (_sx) update");
-
-        assert!(
-            update.finalized_header.is_none(),
-            "no-finality update must yield finalized_header == None"
-        );
-        assert!(
-            update.finality_branch.is_empty(),
-            "no-finality update must yield an empty finality_branch"
-        );
-    }
-}

--- a/src/test_utils/steps.rs
+++ b/src/test_utils/steps.rs
@@ -1,7 +1,8 @@
 //! YAML metadata and step types deserialized from spec test fixtures.
 
-use super::hex_to_root;
+use super::TestUtilsResult;
 use crate::types::consensus::BeaconBlockHeader;
+use crate::types::primitives::Root;
 
 /// Metadata from a spec test's meta.yaml file.
 ///
@@ -56,4 +57,13 @@ pub fn beacon_header_matches(check: &HeaderCheck, header: &BeaconBlockHeader) ->
     let expected_root = hex_to_root(&check.beacon_root).expect("invalid beacon_root hex");
     let actual_root = header.hash_tree_root().expect("hash_tree_root");
     header.slot == check.slot && actual_root == expected_root
+}
+
+/// Convert a hex string (with or without 0x prefix) to a 32-byte root.
+pub(crate) fn hex_to_root(hex: &str) -> TestUtilsResult<Root> {
+    let hex = hex.strip_prefix("0x").unwrap_or(hex);
+    let bytes = hex::decode(hex)?;
+    bytes
+        .try_into()
+        .map_err(|b: Vec<u8>| format!("expected 32 bytes, got {}", b.len()).into())
 }

--- a/src/test_utils/steps.rs
+++ b/src/test_utils/steps.rs
@@ -7,7 +7,7 @@ use crate::types::primitives::Root;
 /// Metadata from a spec test's meta.yaml file.
 ///
 /// The fork-digest keys are unmodeled; serde ignores them (fork comes from the
-/// `SpecTestLoader` constructor).
+/// `LightClientSyncTest` constructor).
 #[derive(Debug, serde::Deserialize)]
 pub(crate) struct TestMeta {
     pub(crate) genesis_validators_root: String,

--- a/tests/light_client_sync.rs
+++ b/tests/light_client_sync.rs
@@ -8,39 +8,41 @@
 #![cfg(feature = "test-utils")]
 
 use eth_light_client::test_utils::{
-    beacon_header_matches, ProcessUpdateStep, SpecTestLoader, TestStep,
+    beacon_header_matches, LightClientSyncTest, ProcessUpdateStep, TestStep,
 };
 use eth_light_client::{LightClient, UpdateOutcome};
 
 #[test]
 fn altair_sync_via_public_api() {
-    run_public_api_sync(SpecTestLoader::minimal_altair_sync());
+    run_public_api_sync(LightClientSyncTest::minimal_altair());
 }
 
 #[test]
 fn bellatrix_sync_via_public_api() {
-    run_public_api_sync(SpecTestLoader::minimal_bellatrix_sync());
+    run_public_api_sync(LightClientSyncTest::minimal_bellatrix());
 }
 
 #[test]
 fn capella_sync_via_public_api() {
-    run_public_api_sync(SpecTestLoader::minimal_capella_sync());
+    run_public_api_sync(LightClientSyncTest::minimal_capella());
 }
 
 /// Replay the fixture's `process_update` steps through the public `LightClient`
-/// API; the fork is determined by `loader`.
-fn run_public_api_sync(loader: SpecTestLoader) {
-    let bootstrap = loader.load_bootstrap().expect("Failed to load bootstrap");
-    let steps = loader.load_steps().expect("Failed to load steps");
+/// API; the fork is determined by `sync_test`.
+fn run_public_api_sync(sync_test: LightClientSyncTest) {
+    let bootstrap = sync_test
+        .load_bootstrap()
+        .expect("Failed to load bootstrap");
+    let steps = sync_test.load_steps().expect("Failed to load steps");
 
-    let mut client =
-        LightClient::new(loader.chain_spec(), bootstrap).expect("Failed to initialize LightClient");
+    let mut client = LightClient::new(sync_test.chain_spec(), bootstrap)
+        .expect("Failed to initialize LightClient");
 
     let mut processed = 0;
     for (i, step) in steps.iter().enumerate() {
         match step {
             TestStep::ProcessUpdate { process_update } => {
-                process_step(&mut client, &loader, process_update, i + 1);
+                process_step(&mut client, &sync_test, process_update, i + 1);
                 processed += 1;
             }
             // later steps depend on force_update's transition -- stop, don't skip
@@ -55,11 +57,11 @@ fn run_public_api_sync(loader: SpecTestLoader) {
 
 fn process_step(
     client: &mut LightClient,
-    loader: &SpecTestLoader,
+    sync_test: &LightClientSyncTest,
     step: &ProcessUpdateStep,
     step_num: usize,
 ) {
-    let update = loader
+    let update = sync_test
         .load_update(&step.update)
         .expect("Failed to load update");
 


### PR DESCRIPTION
Round 2 of the `test_utils` audit. Mostly test-only, with one deliberate production change (`config.rs`, called out below). Green in both feature modes (`cargo test` and `cargo test --features test-utils`: 76 unit + 3 integration + doc tests). Each commit is self-contained.

## Commits
- **`hex_to_root` → `steps.rs`** — round 1 put it in `mod.rs` sorting by output type (`→ Root`); wrong axis. By *concern* it's a fixture-field helper (the hex strings it parses are fields of the `steps` YAML types), so it belongs beside `beacon_header_matches`. `mod.rs` goes back to pure wiring.
- **drop the redundant no-finality converter test** — `raw_ssz`'s `no_finality_update_yields_none_finalized_header` asserted a property the sync harnesses already exercise (they replay the same `_sx` update). It also had a brittle hardcoded fixture hash, an overclaiming comment, and — the real smell — a **layering inversion**: the bottom-layer converter module reached up to the top-level loader to build its input. Deleting it removes that `SpecTestLoader` import from `raw_ssz` entirely.
- **single-source the minimal `ChainSpec` config** *(production)* — `fork.rs` re-typed the whole minimal preset (preset values **plus every fork version**) that `ChainSpec::minimal()` already defined. Two copies of consensus-critical fork versions is a drift risk in itself. Added `ChainSpecConfig::minimal()` as the one source; `ChainSpec::minimal()` now derives from it (via an extracted `from_config` that also backs `try_from_config`, so `config.rs` keeps one copy too); `fork.rs`'s `config()` is `ChainSpecConfig::minimal()` + the per-fork epoch overrides — the only genuinely fork-specific part. `ChainSpec::minimal()` is byte-identical (config tests green).
- **drift-guard test** — nothing verified `fork.rs`'s minimal schedule matches the fixtures it replays, and fork versions feed signing domains, so silent disagreement would be a real verification bug. Per fork, parse the vendored `config.yaml` and assert the config half agrees; the preset half isn't vendored, so for it assert only `PRESET_BASE == minimal`. After the dedup this transitively validates `ChainSpecConfig::minimal()` against the official fixtures. Verified non-vacuous.
- **rename `SpecTestLoader` → `LightClientSyncTest`** — the type is 100% light-client-sync-specific (every constructor targets `.../light_client/sync/...`, every `load_*` reads that suite's files), so the old name over-scoped and "Loader" mislabeled what is really a scenario handle (one fork's sync test: config + inputs). Dropped the now-redundant `_sync` from constructors (`minimal_altair_sync` → `minimal_altair`); renamed `loader` bindings to `sync_test`. Public (test-utils) API change.

## Production impact
Only `config.rs`: added `ChainSpecConfig::minimal()`, routed `ChainSpec::minimal()`/`try_from_config` through a shared `from_config`. `ChainSpec::minimal()` output is unchanged (existing config unit tests pass unmodified). No behavior change.

## Out of scope (follow-up)
`preset_name: "custom"` wart; `minimal()` public-API purity (a `#[cfg]`-gate would be breaking); `steps` `pub` vs `pub(crate)` + shape/modeling (`String` vs `Root`, `execution_root: Option`, dead `trusted_block_root` #55); a `LightClientSyncTest` API-surface confirmation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)