### PR TITLE
refactor: test_utils audit round 3 — typed fixture roots + surface cleanup

### DIFF
--- a/src/consensus/light_client_spec_tests.rs
+++ b/src/consensus/light_client_spec_tests.rs
@@ -9,10 +9,9 @@
 //! it's unimplemented and later steps depend on its state transition.
 
 use crate::consensus::light_client::LightClientProcessor;
-use crate::test_utils::{
-    beacon_header_matches, hex_to_root, LightClientSyncTest, ProcessUpdateStep, TestStep,
-};
+use crate::test_utils::{beacon_header_matches, LightClientSyncTest, ProcessUpdateStep, TestStep};
 use crate::types::consensus::LightClientHeader;
+use crate::types::primitives::Root;
 
 #[test]
 fn altair_sync_via_processor() {
@@ -122,16 +121,15 @@ fn execute_process_update_step(
 
 fn assert_execution_root(
     header: &LightClientHeader,
-    expected_hex: &str,
+    expected: &Root,
     label: &str,
     step_num: usize,
 ) {
-    let expected = hex_to_root(expected_hex).expect("Invalid execution_root hex");
     match header {
         LightClientHeader::Capella(h) => {
             let actual = h.execution.hash_tree_root();
             assert!(
-                actual == expected,
+                actual == *expected,
                 "step {}: {} execution_root mismatch: expected {}, got {}",
                 step_num,
                 label,

--- a/src/test_utils/README.md
+++ b/src/test_utils/README.md
@@ -20,7 +20,7 @@ the light client against the official vectors with no network or beacon node.
 |------|----------------|
 | `loader.rs` | `LightClientSyncTest` — the entry point; reads fixture files and returns typed objects |
 | `raw_ssz.rs` | `Raw*` SSZ structs + the `raw_*_to_pub` raw→production converters |
-| `steps.rs` | YAML fixture types (`meta.yaml` / `steps.yaml`) + the `hex_to_root` / `beacon_header_matches` fixture helpers |
+| `steps.rs` | YAML fixture types (`meta.yaml` / `steps.yaml`, hex roots parsed to `Root` at load) + `beacon_header_matches` |
 | `fork.rs` | `MinimalPresetFork` — the minimal-preset fork tag and its `ChainSpec` |
 | `mod.rs` | module wiring / re-exports |
 

--- a/src/test_utils/loader.rs
+++ b/src/test_utils/loader.rs
@@ -22,31 +22,23 @@ pub struct LightClientSyncTest {
 }
 
 impl LightClientSyncTest {
+    fn new(fork: MinimalPresetFork, dir: &str) -> Self {
+        let test_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join(format!(
+            "tests/fixtures/minimal/{dir}/light_client/sync/light_client_sync"
+        ));
+        Self { test_dir, fork }
+    }
+
     pub fn minimal_altair() -> Self {
-        let test_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/fixtures/minimal/altair/light_client/sync/light_client_sync");
-        Self {
-            test_dir,
-            fork: MinimalPresetFork::Altair,
-        }
+        Self::new(MinimalPresetFork::Altair, "altair")
     }
 
     pub fn minimal_bellatrix() -> Self {
-        let test_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/fixtures/minimal/bellatrix/light_client/sync/light_client_sync");
-        Self {
-            test_dir,
-            fork: MinimalPresetFork::Bellatrix,
-        }
+        Self::new(MinimalPresetFork::Bellatrix, "bellatrix")
     }
 
     pub fn minimal_capella() -> Self {
-        let test_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/fixtures/minimal/capella/light_client/sync/light_client_sync");
-        Self {
-            test_dir,
-            fork: MinimalPresetFork::Capella,
-        }
+        Self::new(MinimalPresetFork::Capella, "capella")
     }
 
     pub fn chain_spec(&self) -> crate::config::ChainSpec {

--- a/src/test_utils/loader.rs
+++ b/src/test_utils/loader.rs
@@ -6,7 +6,7 @@ use super::raw_ssz::{
     RawCapellaLightClientUpdate, RawLightClientBootstrap, RawLightClientUpdate,
 };
 use super::steps::{TestMeta, TestStep};
-use super::{hex_to_root, MinimalPresetFork, TestUtilsResult};
+use super::{MinimalPresetFork, TestUtilsResult};
 use crate::types::consensus::{LightClientBootstrap, LightClientUpdate};
 use ssz_rs::prelude::*;
 use std::fs;
@@ -55,7 +55,7 @@ impl LightClientSyncTest {
 
     pub fn load_bootstrap(&self) -> TestUtilsResult<LightClientBootstrap> {
         let meta = self.load_meta()?;
-        let genesis_validators_root = hex_to_root(&meta.genesis_validators_root)?;
+        let genesis_validators_root = meta.genesis_validators_root;
         let bootstrap_path = self.test_dir.join("bootstrap.ssz_snappy");
 
         match self.fork {

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -9,7 +9,6 @@ pub use loader::LightClientSyncTest;
 pub use steps::{beacon_header_matches, HeaderCheck, ProcessUpdateStep, StateChecks, TestStep};
 
 pub(crate) use fork::MinimalPresetFork;
-pub(crate) use steps::hex_to_root;
 
 /// Box<dyn Error>, not `crate::error::Result`: test glue stays decoupled from the production error enum.
 pub(crate) type TestUtilsResult<T> = Result<T, Box<dyn std::error::Error>>;

--- a/src/test_utils/steps.rs
+++ b/src/test_utils/steps.rs
@@ -3,6 +3,7 @@
 use super::TestUtilsResult;
 use crate::types::consensus::BeaconBlockHeader;
 use crate::types::primitives::Root;
+use serde::Deserialize;
 
 /// Metadata from a spec test's meta.yaml file.
 ///
@@ -10,10 +11,12 @@ use crate::types::primitives::Root;
 /// `LightClientSyncTest` constructor).
 #[derive(Debug, serde::Deserialize)]
 pub(crate) struct TestMeta {
-    pub(crate) genesis_validators_root: String,
+    #[serde(deserialize_with = "de_root")]
+    pub(crate) genesis_validators_root: Root,
     /// Parsed but not yet enforced; see issue #55.
     #[allow(dead_code)]
-    trusted_block_root: String,
+    #[serde(deserialize_with = "de_root")]
+    trusted_block_root: Root,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -25,10 +28,11 @@ pub struct StateChecks {
 #[derive(Debug, serde::Deserialize)]
 pub struct HeaderCheck {
     pub slot: u64,
-    pub beacon_root: String,
+    #[serde(deserialize_with = "de_root")]
+    pub beacon_root: Root,
     /// Present only for Capella+ (absent for Altair/Bellatrix).
-    #[serde(default)]
-    pub execution_root: Option<String>,
+    #[serde(default, deserialize_with = "de_root_opt")]
+    pub execution_root: Option<Root>,
 }
 
 /// A single test step from steps.yaml.
@@ -54,13 +58,32 @@ pub struct ProcessUpdateStep {
 /// `execution_root` is not checked here, since only the processor exposes the
 /// full light client header.
 pub fn beacon_header_matches(check: &HeaderCheck, header: &BeaconBlockHeader) -> bool {
-    let expected_root = hex_to_root(&check.beacon_root).expect("invalid beacon_root hex");
     let actual_root = header.hash_tree_root().expect("hash_tree_root");
-    header.slot == check.slot && actual_root == expected_root
+    header.slot == check.slot && actual_root == check.beacon_root
+}
+
+/// Deserialize a hex root string (`meta.yaml` / `steps.yaml`) into a `Root`,
+/// so malformed hex fails at load time rather than at assertion time.
+fn de_root<'de, D>(deserializer: D) -> Result<Root, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    hex_to_root(&s).map_err(serde::de::Error::custom)
+}
+
+fn de_root_opt<'de, D>(deserializer: D) -> Result<Option<Root>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<String>::deserialize(deserializer)?
+        .map(|s| hex_to_root(&s))
+        .transpose()
+        .map_err(serde::de::Error::custom)
 }
 
 /// Convert a hex string (with or without 0x prefix) to a 32-byte root.
-pub(crate) fn hex_to_root(hex: &str) -> TestUtilsResult<Root> {
+fn hex_to_root(hex: &str) -> TestUtilsResult<Root> {
     let hex = hex.strip_prefix("0x").unwrap_or(hex);
     let bytes = hex::decode(hex)?;
     bytes


### PR DESCRIPTION
Round 3 of the `test_utils` audit. Test-only; green in both feature modes (`cargo test` and `cargo test --features test-utils`: 76 unit + 3 integration + doc tests). Two commits.

## Commits
- **parse fixture hex roots at deserialize time** — the fixture check fields (`genesis_validators_root`, `trusted_block_root`, `beacon_root`, `execution_root`) were stringly-typed hex, parsed to `Root` ad-hoc at each use via `hex_to_root`, with `.expect()` panics scattered across two files and malformed hex failing *late* (mid-assertion). Typed them as `Root` / `Option<Root>` with a serde `deserialize_with` (`de_root` / `de_root_opt`) that hex-decodes during `load_meta`/`load_steps`. Now the types say `Root`, call sites compare roots directly (`beacon_header_matches` and `assert_execution_root` drop their `hex_to_root`/`.expect()`), and bad hex fails once at load time as a `Result` the harness already propagates. Cascade: those were `hex_to_root`'s only external callers, so it drops to a private `steps.rs` helper and the `mod.rs` re-export is gone. `execution_root` stays `Option<Root>` (Option models "maybe pre-Capella" correctly).
- **dedup `LightClientSyncTest` constructors** — API-surface pass confirmed the surface is clean (every public method has live callers; `load_meta` correctly `pub(crate)`, rest `pub`; no dead API). The one cleanup: the three `minimal_*` constructors repeated the fixture-path template + struct construction verbatim → extracted a private `new(fork, dir)`, constructors become one-liners, path template lives once.

## Decisions recorded (no code)
- **`preset_name: "custom"` wart** — skipped. `fork.chain_spec()`'s spec reports `"custom"` not `"minimal"`, but `preset_name()` is read only by `config.rs`'s own tests (unobservable), and every fix pays a real cost (breaking API, or dropped validation) to correct a field nobody reads.
- **`steps` `pub` vs `pub(crate)`** — kept `pub`. The surface is minimal and load-bearing; `HeaderCheck`/`StateChecks` are structurally-required serde targets that the external integration test reads by field. The `test-utils` feature is a deliberate external offering.
- Surfaced a real production gap → filed #61 (expose verified execution state root on the public `LightClient`).

## Out of scope (follow-up)
`minimal()` public-API purity (a `#[cfg]`-gate would be breaking); #61; the `ChainSpec::minimal()` (derived) vs `mainnet()` (literal) construction asymmetry noted for a possible `config.rs` follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)