### PR TITLE
refactor: config-audit — dead-surface cleanup, construction unification, src/ module map

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -4,32 +4,20 @@ How to think about each top-level module. Currently covers `config`; more
 modules to be documented over time.
 
 ## `config` — the network rulebook & fork oracle
+The `config` module is the single source of truth for **network parameters** and the **fork schedule**. The rest of the crate consults it for two things:
+1. *A network's constants* — genesis time, seconds/slot, slots/epoch,
+   sync-committee period math, committee size.  Each network defines its own fork rules/parameters.
+2. *Which fork's rules/parameters apply (within a specific network) at a given slot/epoch*.
 
-`config` is the single source of truth for **network parameters** and **fork
-dispatch**. The rest of the crate consults it for two things:
-
-1. *This network's constants* — genesis time, seconds/slot, slots/epoch,
-   sync-committee period math, committee size.
-2. *Which fork's rules apply at a given slot/epoch, and its parameters* — the
-   core job, and the home of the crate's explicit fork-awareness.
-
-It owns exactly two consensus-critical dispatches:
-
+This module owns two consensus-critical, fork-dependent lookups:
 - `fork_version_at_epoch` → the signing **domain** (sync-committee sig checks)
 - `*_gindex(slot)` → the Merkle **generalized indices** (proof checks)
 
-Everything downstream branches on `Fork`; `config` is the one place that maps
-`slot/epoch → Fork → parameters`.
-
-**It holds no verification behavior** — no SSZ, Merkle, or signature logic, only
-data and pure lookups. Verification lives in `consensus/`, parameterized by what
-`config` returns:
-
-> `config` = inert, correctness-critical data + pure lookups
-> `consensus` = behavior driven by that data
+**The module holds no verification behavior** — no SSZ, Merkle, or signature logic, only data and pure lookups. Verification lives in `consensus/`, parameterized by what `config` returns:
+> `config` module = inert, correctness-critical data + pure lookups
+> `consensus` module = contains behavior driven by that data
 
 ### Two layers (parse, don't validate)
-
 | Type | Role |
 |------|------|
 | `ChainSpecConfig` | Raw, untrusted **input**. Public fields, constructible/deserializable, *can be invalid*. |
@@ -38,11 +26,7 @@ data and pure lookups. Verification lives in `consensus/`, parameterized by what
 `try_from_config` validates; `from_config` is the *one* place the config→spec
 mapping lives. Once code holds a `ChainSpec`, it trusts it.
 
-### Why it's handled carefully
+### Handle this module carefully
+`config` sits near the **floor** of the dependency graph (depends only on `error` + `types::primitives`); nearly everything consensus-y depends on it. So it's foundational.  The module should be stable and low-churn.
 
-`config` sits near the **floor** of the dependency graph (depends only on
-`error` + `types::primitives`); nearly everything consensus-y depends on it. So
-it's foundational, stable, and low-churn — its surface should be exactly the
-questions the rest of the repo legitimately asks. It's also where each **new
-fork lands** (a `ForkParams`, a gindex arm, a fork version) as support advances
-(Deneb → Electra → Fulu).
+It's also where each **new fork lands** (a `ForkParams`, a gindex arm, a fork version) as support advances (Deneb → Electra → Fulu).

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,48 @@
+# `src/` — module map
+
+How to think about each top-level module. Currently covers `config`; more
+modules to be documented over time.
+
+## `config` — the network rulebook & fork oracle
+
+`config` is the single source of truth for **network parameters** and **fork
+dispatch**. The rest of the crate consults it for two things:
+
+1. *This network's constants* — genesis time, seconds/slot, slots/epoch,
+   sync-committee period math, committee size.
+2. *Which fork's rules apply at a given slot/epoch, and its parameters* — the
+   core job, and the home of the crate's explicit fork-awareness.
+
+It owns exactly two consensus-critical dispatches:
+
+- `fork_version_at_epoch` → the signing **domain** (sync-committee sig checks)
+- `*_gindex(slot)` → the Merkle **generalized indices** (proof checks)
+
+Everything downstream branches on `Fork`; `config` is the one place that maps
+`slot/epoch → Fork → parameters`.
+
+**It holds no verification behavior** — no SSZ, Merkle, or signature logic, only
+data and pure lookups. Verification lives in `consensus/`, parameterized by what
+`config` returns:
+
+> `config` = inert, correctness-critical data + pure lookups
+> `consensus` = behavior driven by that data
+
+### Two layers (parse, don't validate)
+
+| Type | Role |
+|------|------|
+| `ChainSpecConfig` | Raw, untrusted **input**. Public fields, constructible/deserializable, *can be invalid*. |
+| `ChainSpec` | The **validated, immutable** runtime object. `#[non_exhaustive]`, `const fn` accessors only. |
+
+`try_from_config` validates; `from_config` is the *one* place the config→spec
+mapping lives. Once code holds a `ChainSpec`, it trusts it.
+
+### Why it's handled carefully
+
+`config` sits near the **floor** of the dependency graph (depends only on
+`error` + `types::primitives`); nearly everything consensus-y depends on it. So
+it's foundational, stable, and low-churn — its surface should be exactly the
+questions the rest of the repo legitimately asks. It's also where each **new
+fork lands** (a `ForkParams`, a gindex arm, a fork version) as support advances
+(Deneb → Electra → Fulu).

--- a/src/config.rs
+++ b/src/config.rs
@@ -301,21 +301,29 @@ impl ChainSpec {
         altair_fork_epoch: u64,
         bellatrix_fork_epoch: u64,
     ) -> Self {
-        Self {
-            preset_name: "test",
-            genesis_time: 0,
-            seconds_per_slot: 12,
-            slots_per_epoch,
-            epochs_per_sync_committee_period: 8,
-            sync_committee_size: 32,
-            fork_schedule: ForkSchedule::new(
-                ForkParams::new(altair_fork_version, altair_fork_epoch),
-                ForkParams::new(bellatrix_fork_version, bellatrix_fork_epoch),
-                ForkParams::new([0x02, 0x00, 0x00, 0x00], u64::MAX),
-                ForkParams::new([0x03, 0x00, 0x00, 0x00], u64::MAX),
-                ForkParams::new([0x04, 0x00, 0x00, 0x00], u64::MAX),
-            ),
-        }
+        // Later forks are pinned past reach (u64::MAX), so their versions are
+        // never active; values are placeholders. from_config keeps this on the
+        // single config->spec mapping.
+        Self::from_config(
+            ChainSpecConfig {
+                genesis_time: 0,
+                seconds_per_slot: 12,
+                slots_per_epoch,
+                epochs_per_sync_committee_period: 8,
+                sync_committee_size: 32,
+                altair_fork_version,
+                bellatrix_fork_version,
+                capella_fork_version: [0x03, 0x00, 0x00, 0x00],
+                deneb_fork_version: [0x04, 0x00, 0x00, 0x00],
+                electra_fork_version: [0x05, 0x00, 0x00, 0x00],
+                altair_fork_epoch,
+                bellatrix_fork_epoch,
+                capella_fork_epoch: u64::MAX,
+                deneb_fork_epoch: u64::MAX,
+                electra_fork_epoch: u64::MAX,
+            },
+            "test",
+        )
     }
 
     pub const fn preset_name(&self) -> &'static str {

--- a/src/config.rs
+++ b/src/config.rs
@@ -402,12 +402,6 @@ impl ChainSpec {
         self.fork_schedule.version_at_epoch(epoch)
     }
 
-    /// Get the fork version for a given slot.
-    #[allow(dead_code)] // Will be used in future fork-aware update processing
-    pub(crate) const fn fork_version_at_slot(&self, slot: Slot) -> [u8; 4] {
-        self.fork_version_at_epoch(slot / self.slots_per_epoch)
-    }
-
     // Beacon State Generalized Indices
     //
     // These return the SSZ generalized index for various beacon state fields.

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,11 +84,6 @@ impl ForkSchedule {
             Fork::Electra => self.electra.version(),
         }
     }
-
-    #[allow(dead_code)]
-    pub(crate) const fn altair_version(&self) -> [u8; 4] {
-        self.altair.version()
-    }
 }
 
 /// Configurations for creating a [`ChainSpec`].
@@ -347,11 +342,6 @@ impl ChainSpec {
         self.sync_committee_size
     }
 
-    #[allow(dead_code)]
-    pub(crate) const fn altair_fork_version(&self) -> [u8; 4] {
-        self.fork_schedule.altair_version()
-    }
-
     /// Calculate total slots per sync committee period
     pub const fn slots_per_sync_committee_period(&self) -> u64 {
         self.slots_per_epoch * self.epochs_per_sync_committee_period
@@ -463,7 +453,8 @@ mod tests {
         assert_eq!(spec.epochs_per_sync_committee_period(), 256);
         assert_eq!(spec.sync_committee_size(), 512);
         assert_eq!(spec.slots_per_sync_committee_period(), 8192);
-        assert_eq!(spec.altair_fork_version(), [0x01, 0x00, 0x00, 0x00]);
+        // Altair version via the live path (Altair is the genesis fork for the LC).
+        assert_eq!(spec.fork_version_at_epoch(0), [0x01, 0x00, 0x00, 0x00]);
     }
 
     #[test]
@@ -474,7 +465,7 @@ mod tests {
         assert_eq!(spec.epochs_per_sync_committee_period(), 8);
         assert_eq!(spec.sync_committee_size(), 32);
         assert_eq!(spec.slots_per_sync_committee_period(), 64);
-        assert_eq!(spec.altair_fork_version(), [0x01, 0x00, 0x00, 0x01]);
+        assert_eq!(spec.fork_version_at_epoch(0), [0x01, 0x00, 0x00, 0x01]);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,20 +11,6 @@ pub(crate) enum Fork {
     Electra,   // Pectra upgrade (2025). BeaconState restructured, gindice change.
 }
 
-impl Fork {
-    /// Returns the fork name as used in spec test paths.
-    #[allow(dead_code)] // Will be used when loading fork-specific test fixtures
-    pub(crate) fn name(&self) -> &'static str {
-        match self {
-            Fork::Altair => "altair",
-            Fork::Bellatrix => "bellatrix",
-            Fork::Capella => "capella",
-            Fork::Deneb => "deneb",
-            Fork::Electra => "electra",
-        }
-    }
-}
-
 /// Fork version and activation epoch for a single fork.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ForkParams {
@@ -620,15 +606,6 @@ mod tests {
         assert!(Fork::Bellatrix < Fork::Capella);
         assert!(Fork::Capella < Fork::Deneb);
         assert!(Fork::Deneb < Fork::Electra);
-    }
-
-    #[test]
-    fn test_fork_name() {
-        assert_eq!(Fork::Altair.name(), "altair");
-        assert_eq!(Fork::Bellatrix.name(), "bellatrix");
-        assert_eq!(Fork::Capella.name(), "capella");
-        assert_eq!(Fork::Deneb.name(), "deneb");
-        assert_eq!(Fork::Electra.name(), "electra");
     }
 
     // Generalized Index Tests

--- a/src/test_utils/fork.rs
+++ b/src/test_utils/fork.rs
@@ -11,6 +11,15 @@ pub(crate) enum MinimalPresetFork {
 }
 
 impl MinimalPresetFork {
+    /// Spec name / fixture directory for this fork.
+    pub(crate) fn name(&self) -> &'static str {
+        match self {
+            MinimalPresetFork::Altair => "altair",
+            MinimalPresetFork::Bellatrix => "bellatrix",
+            MinimalPresetFork::Capella => "capella",
+        }
+    }
+
     /// Return a `ChainSpec` whose fork schedule matches the spec-test fixtures
     /// for this fork.
     pub(crate) fn chain_spec(&self) -> crate::config::ChainSpec {
@@ -59,11 +68,7 @@ mod tests {
     }
 
     fn load_config_yaml(fork: MinimalPresetFork) -> ConfigYaml {
-        let dir = match fork {
-            MinimalPresetFork::Altair => "altair",
-            MinimalPresetFork::Bellatrix => "bellatrix",
-            MinimalPresetFork::Capella => "capella",
-        };
+        let dir = fork.name();
         let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(format!(
             "tests/fixtures/minimal/{dir}/light_client/sync/light_client_sync/config.yaml"
         ));

--- a/src/test_utils/loader.rs
+++ b/src/test_utils/loader.rs
@@ -22,7 +22,8 @@ pub struct LightClientSyncTest {
 }
 
 impl LightClientSyncTest {
-    fn new(fork: MinimalPresetFork, dir: &str) -> Self {
+    fn new(fork: MinimalPresetFork) -> Self {
+        let dir = fork.name();
         let test_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join(format!(
             "tests/fixtures/minimal/{dir}/light_client/sync/light_client_sync"
         ));
@@ -30,15 +31,15 @@ impl LightClientSyncTest {
     }
 
     pub fn minimal_altair() -> Self {
-        Self::new(MinimalPresetFork::Altair, "altair")
+        Self::new(MinimalPresetFork::Altair)
     }
 
     pub fn minimal_bellatrix() -> Self {
-        Self::new(MinimalPresetFork::Bellatrix, "bellatrix")
+        Self::new(MinimalPresetFork::Bellatrix)
     }
 
     pub fn minimal_capella() -> Self {
-        Self::new(MinimalPresetFork::Capella, "capella")
+        Self::new(MinimalPresetFork::Capella)
     }
 
     pub fn chain_spec(&self) -> crate::config::ChainSpec {


### PR DESCRIPTION
## Summary

Config-module audit: tighten `config.rs`'s surface, unify how a `ChainSpec` is
constructed, and add a `src/` module map documenting how to think about the
module. No behavior changes — pure cleanup + docs.

## Changes

**Dead / test-only surface removed** (`config.rs` now has **zero** `#[allow(dead_code)]`):
- Drop `ChainSpec::altair_fork_version()` + `ForkSchedule::altair_version()` — a
  two-level dead chain that only two preset tests used; rewrite those asserts
  against the live `fork_version_at_epoch(0)`.
- Drop `ChainSpec::fork_version_at_slot()` — an unused slot→epoch wrapper kept
  behind a "will be used later" placeholder.

**Single-sourcing / construction unification:**
- Fork-name strings (`"altair"`/`"bellatrix"`/`"capella"`) were duplicated
  across the `LightClientSyncTest` constructors and the `fork.rs` drift-test
  match, with a parallel `config::Fork::name()` only test code could reach. Move
  the mapping onto `MinimalPresetFork::name()` as the single source; drop
  `config::Fork::name()` (production naming is covered by `Debug`).
- Route `ChainSpec::for_test` through `from_config`, removing the last
  hand-assembled `ChainSpec` literal outside `mainnet()`. `from_config` is now
  the single config→spec mapping in the crate.

**Docs:**
- Add `src/README.md` — an extensible module map, seeded with a concise "how to
  think about `config`" section (network rulebook / fork oracle, the two
  fork-dependent lookups, the data-not-behavior split vs `consensus/`, and the
  `ChainSpecConfig → ChainSpec` parse-don't-validate boundary).

## Not in scope (tracked separately)
- **#63** — `validate()`'s `altair_fork_epoch == 0` rule vs real mainnet; why
  `mainnet()` is a validation-bypassing literal.
- **#21** — `sync_committee_size` only partially drives the (512-fixed)
  `SyncCommittee` type.

## Testing
- `cargo test --features test-utils` — all pass.
- `cargo clippy --features test-utils --all-targets` — no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
