### PR TITLE
refactor: config-audit-2 — route mainnet through from_config, resolve #63 (altair-from-genesis rule)

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -26,6 +26,29 @@ This module owns two consensus-critical, fork-dependent lookups:
 `try_from_config` validates; `from_config` is the *one* place the config→spec
 mapping lives. Once code holds a `ChainSpec`, it trusts it.
 
+```mermaid
+flowchart TD
+    cfg["ChainSpecConfig<br/> ingests raw input params"]
+
+    cfg --> tfc["try_from_config()"]
+    tfc --> v{"validate()"}
+    v -->|Err| err["Err(InvalidInput)"]
+    v -->|Ok| fc["from_config()<br/>single config-to-spec<br/>mapping"]
+
+    main["mainnet()"] --> fc
+    min["minimal()"] --> fc
+    ft["for_test()"] --> fc
+
+    fc --> spec["ChainSpec<br/>validated<br/>immutable · trusted"]
+```
+
+The validated door (`try_from_config`) is the only path that checks input; the
+trusted presets (`minimal`, `mainnet`, `for_test`) skip `validate()` but still
+go through the single `from_config` mapping. `mainnet()` skips `validate()` not
+just as a trust optimization but out of necessity: today's `validate()` rejects
+Altair at a nonzero epoch, and real mainnet activates Altair at epoch 74240 —
+see issue #63.
+
 ### Handle this module carefully
 `config` sits near the **floor** of the dependency graph (depends only on `error` + `types::primitives`); nearly everything consensus-y depends on it. So it's foundational.  The module should be stable and low-churn.
 

--- a/src/README.md
+++ b/src/README.md
@@ -43,11 +43,10 @@ flowchart TD
 ```
 
 The validated door (`try_from_config`) is the only path that checks input; the
-trusted presets (`minimal`, `mainnet`, `for_test`) skip `validate()` but still
-go through the single `from_config` mapping. `mainnet()` skips `validate()` not
-just as a trust optimization but out of necessity: today's `validate()` rejects
-Altair at a nonzero epoch, and real mainnet activates Altair at epoch 74240 —
-see issue #63.
+trusted presets (`minimal`, `mainnet`, `for_test`) skip `validate()` as a
+`const` construction optimization but still go through the single `from_config`
+mapping. Their params are known-good, so `try_from_config` would accept them
+just the same.
 
 ### Handle this module carefully
 `config` sits near the **floor** of the dependency graph (depends only on `error` + `types::primitives`); nearly everything consensus-y depends on it. So it's foundational.  The module should be stable and low-churn.

--- a/src/config.rs
+++ b/src/config.rs
@@ -164,6 +164,27 @@ impl ChainSpecConfig {
         }
     }
 
+    /// Single source of truth for the Ethereum mainnet parameters.
+    pub const fn mainnet() -> Self {
+        Self {
+            genesis_time: 1606824023,
+            seconds_per_slot: 12,
+            slots_per_epoch: 32,
+            epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
+            altair_fork_version: [0x01, 0x00, 0x00, 0x00],
+            bellatrix_fork_version: [0x02, 0x00, 0x00, 0x00],
+            capella_fork_version: [0x03, 0x00, 0x00, 0x00],
+            deneb_fork_version: [0x04, 0x00, 0x00, 0x00],
+            electra_fork_version: [0x05, 0x00, 0x00, 0x00],
+            altair_fork_epoch: 74240,
+            bellatrix_fork_epoch: 144896,
+            capella_fork_epoch: 194048,
+            deneb_fork_epoch: 269568,
+            electra_fork_epoch: 364544,
+        }
+    }
+
     /// Validate the configuration.
     ///
     /// Returns an error if any values are invalid or inconsistent.
@@ -240,23 +261,13 @@ pub struct ChainSpec {
 }
 
 impl ChainSpec {
-    /// Ethereum mainnet specification
+    /// Ethereum mainnet specification, from [`ChainSpecConfig::mainnet`].
+    ///
+    /// A trusted preset: routed through the single `from_config` mapping, but
+    /// skips `validate()` (which enforces this impl's Altair-from-genesis limit
+    /// that real mainnet — Altair at epoch 74240 — does not satisfy). See #63.
     pub const fn mainnet() -> Self {
-        Self {
-            preset_name: "mainnet",
-            genesis_time: 1606824023,
-            seconds_per_slot: 12,
-            slots_per_epoch: 32,
-            epochs_per_sync_committee_period: 256,
-            sync_committee_size: 512,
-            fork_schedule: ForkSchedule::new(
-                ForkParams::new([0x01, 0x00, 0x00, 0x00], 74240),
-                ForkParams::new([0x02, 0x00, 0x00, 0x00], 144896),
-                ForkParams::new([0x03, 0x00, 0x00, 0x00], 194048),
-                ForkParams::new([0x04, 0x00, 0x00, 0x00], 269568),
-                ForkParams::new([0x05, 0x00, 0x00, 0x00], 364544),
-            ),
-        }
+        Self::from_config(ChainSpecConfig::mainnet(), "mainnet")
     }
 
     /// Minimal test spec, from [`ChainSpecConfig::minimal`].

--- a/src/config.rs
+++ b/src/config.rs
@@ -134,7 +134,8 @@ pub struct ChainSpecConfig {
     pub deneb_fork_version: [u8; 4],
     pub electra_fork_version: [u8; 4],
 
-    /// Must be 0 (light client protocol requires Altair from genesis).
+    /// Altair activation epoch; the monotonic floor of the fork schedule
+    /// (may be nonzero, e.g. mainnet's 74240).
     pub altair_fork_epoch: u64,
     pub bellatrix_fork_epoch: u64,
     pub capella_fork_epoch: u64,
@@ -143,28 +144,6 @@ pub struct ChainSpecConfig {
 }
 
 impl ChainSpecConfig {
-    /// Single source of truth for the minimal preset (spec-test config).
-    pub const fn minimal() -> Self {
-        Self {
-            genesis_time: 1578009600,
-            seconds_per_slot: 6,
-            slots_per_epoch: 8,
-            epochs_per_sync_committee_period: 8,
-            sync_committee_size: 32,
-            altair_fork_version: [0x01, 0x00, 0x00, 0x01],
-            bellatrix_fork_version: [0x02, 0x00, 0x00, 0x01],
-            capella_fork_version: [0x03, 0x00, 0x00, 0x01],
-            deneb_fork_version: [0x04, 0x00, 0x00, 0x01],
-            electra_fork_version: [0x05, 0x00, 0x00, 0x01],
-            altair_fork_epoch: 0,
-            bellatrix_fork_epoch: u64::MAX,
-            capella_fork_epoch: u64::MAX,
-            deneb_fork_epoch: u64::MAX,
-            electra_fork_epoch: u64::MAX,
-        }
-    }
-
-    /// Single source of truth for the Ethereum mainnet parameters.
     pub const fn mainnet() -> Self {
         Self {
             genesis_time: 1606824023,
@@ -185,9 +164,26 @@ impl ChainSpecConfig {
         }
     }
 
-    /// Validate the configuration.
-    ///
-    /// Returns an error if any values are invalid or inconsistent.
+    pub const fn minimal() -> Self {
+        Self {
+            genesis_time: 1578009600,
+            seconds_per_slot: 6,
+            slots_per_epoch: 8,
+            epochs_per_sync_committee_period: 8,
+            sync_committee_size: 32,
+            altair_fork_version: [0x01, 0x00, 0x00, 0x01],
+            bellatrix_fork_version: [0x02, 0x00, 0x00, 0x01],
+            capella_fork_version: [0x03, 0x00, 0x00, 0x01],
+            deneb_fork_version: [0x04, 0x00, 0x00, 0x01],
+            electra_fork_version: [0x05, 0x00, 0x00, 0x01],
+            altair_fork_epoch: 0,
+            bellatrix_fork_epoch: u64::MAX,
+            capella_fork_epoch: u64::MAX,
+            deneb_fork_epoch: u64::MAX,
+            electra_fork_epoch: u64::MAX,
+        }
+    }
+
     pub fn validate(&self) -> Result<()> {
         if self.seconds_per_slot == 0 {
             return Err(Error::InvalidInput(
@@ -212,15 +208,7 @@ impl ChainSpecConfig {
             ));
         }
 
-        // Light client protocol requires Altair from genesis
-        if self.altair_fork_epoch != 0 {
-            return Err(Error::InvalidInput(
-                "altair_fork_epoch must be 0 (light client requires Altair from genesis)"
-                    .to_string(),
-            ));
-        }
-
-        // Fork epochs must be monotonically non-decreasing
+        // Fork epochs must be monotonically non-decreasing, anchored at Altair. The light client operates from Altair onward via its trusted bootstrap, so Altair may activate at any epoch (e.g. mainnet at 74240), not only genesis — it just cannot come after a later fork.
         if self.bellatrix_fork_epoch < self.altair_fork_epoch {
             return Err(Error::InvalidInput(
                 "bellatrix_fork_epoch must be >= altair_fork_epoch".to_string(),
@@ -261,24 +249,15 @@ pub struct ChainSpec {
 }
 
 impl ChainSpec {
-    /// Ethereum mainnet specification, from [`ChainSpecConfig::mainnet`].
-    ///
-    /// A trusted preset: routed through the single `from_config` mapping, but
-    /// skips `validate()` (which enforces this impl's Altair-from-genesis limit
-    /// that real mainnet — Altair at epoch 74240 — does not satisfy). See #63.
     pub const fn mainnet() -> Self {
         Self::from_config(ChainSpecConfig::mainnet(), "mainnet")
     }
 
-    /// Minimal test spec, from [`ChainSpecConfig::minimal`].
     pub const fn minimal() -> Self {
         Self::from_config(ChainSpecConfig::minimal(), "minimal")
     }
 
-    /// Create a ChainSpec from a custom configuration.
-    ///
     /// Use this for local testnets or devnets with non-standard parameters.
-    /// The configuration is validated before the ChainSpec is created.
     pub fn try_from_config(config: ChainSpecConfig) -> Result<Self> {
         config.validate()?;
         Ok(Self::from_config(config, "custom"))
@@ -805,8 +784,15 @@ mod tests {
 
     #[test]
     fn test_chainspec_config_validation_altair_epoch() {
+        // Altair need not activate at genesis: real mainnet (Altair @ 74240)
+        // is a valid config. The LC operates from Altair onward via its trusted
+        // bootstrap, not via a genesis-Altair schedule. See #63.
+        assert!(ChainSpecConfig::mainnet().validate().is_ok());
+
+        // Altair is still the monotonic floor: a later fork before it is invalid.
         let mut config = valid_config();
-        config.altair_fork_epoch = 1; // Must be 0
+        config.altair_fork_epoch = 10;
+        config.bellatrix_fork_epoch = 5;
         assert!(config.validate().is_err());
     }
 


### PR DESCRIPTION
## Summary

Continues the `config` module audit. Two moves, both on the single config→spec mapping and the validation door.

**1. Route `mainnet()` through `from_config` (`656d822`)**
`mainnet()` was a hand-written `ChainSpec` struct literal — a second, drift-prone copy of the mapping `from_config` already owns. Added a `const fn ChainSpecConfig::mainnet()` and built the spec via `from_config`, so every constructor now flows through the one mapping primitive. Output is byte-identical (`test_mainnet_spec` and the mainnet fork/version tests pass unchanged).

**2. Drop the altair-from-genesis validation rule — resolve #63 (`97a8071`)**
`validate()` required `altair_fork_epoch == 0`, which forced real mainnet (Altair @ 74240) to bypass the validated path. The rule conflated two things:
- *the LC operates from Altair onward* — true, guaranteed by the trusted bootstrap
- *Altair activates at genesis* — false for mainnet

The bootstrap guarantees post-Altair operation, not the fork schedule. Verified no production path resolves a pre-Altair epoch/slot:
- `fork_version_at_epoch` (sync-committee domain) is driven by an update's `signature_slot`, always post-Altair by construction.
- the `*_gindex(slot)` helpers only distinguish Electra; the Altair floor lands in the correct non-Electra arm regardless.

Removed the rule. The monotonic-non-decreasing chain already anchors Altair as the schedule floor. `mainnet()` is now an ordinary trusted preset — `try_from_config` would accept it too; it skips `validate()` only for `const` construction, exactly like `minimal()`.

Also: reordered `ChainSpecConfig` constructors to mainnet-then-minimal, inverted the negative test into a positive one (real mainnet config validates) + an altair-is-still-the-floor case, updated field doc and `src/README.md` construction diagram/caption.

## Testing
- `cargo test --features test-utils` — 75 + 3 + 3 pass
- `cargo test --doc` — pass
- `cargo clippy --lib` — clean

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)