### PR TITLE
refactor: ExecutionPayloadHeader goes SSZ-native (#69 PR1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,6 @@ hex = "0.4"
 sha2 = "0.10"
 blst = "0.3.10"  # BLS signatures for beacon chain
 
-# Ethereum-specific types
-ruint = { version = "1.8", features = ["serde"] }
-
 # SSZ and Tree Hashing - Production-grade libraries used by Lighthouse
 ethereum_ssz = "0.5"        # SSZ encoding/decoding
 ethereum_ssz_derive = "0.5" # SSZ derive macros
@@ -31,6 +28,8 @@ ssz_rs = "0.9"              # SSZ decode of wire bytes into public types (see RE
 
 # Error handling
 thiserror = "1.0"
+ssz_types = "0.5"
+ethereum-types = "0.14"
 
 [features]
 default = []

--- a/src/types/consensus.rs
+++ b/src/types/consensus.rs
@@ -1,9 +1,10 @@
 use crate::config::{ChainSpec, Fork};
 use crate::error::{Error, Result};
-use crate::types::primitives::{
-    Address, BLSPublicKey, BLSSignature, Bloom, Epoch, ExtraData, Root, Slot, ValidatorIndex, U256,
-};
+use crate::types::primitives::{BLSPublicKey, BLSSignature, Epoch, Root, Slot, ValidatorIndex};
+use ethereum_types::{Address, U256};
 use ssz_derive::{Decode, Encode};
+use ssz_types::typenum::{U256 as BloomLen, U32 as MaxExtraData};
+use ssz_types::{FixedVector, VariableList};
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 
@@ -62,7 +63,7 @@ impl BeaconBlockHeader {
 ///
 /// Verification logic accesses the inner `BeaconBlockHeader` through
 /// [`beacon()`](Self::beacon), keeping the pipeline fork-agnostic.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 pub enum LightClientHeader {
     Altair(AltairLightClientHeader),
@@ -91,7 +92,7 @@ pub struct BellatrixLightClientHeader {
 /// Starting at Capella, the `LightClientHeader` includes an execution
 /// payload header and a merkle branch proving it is embedded in
 /// `beacon.body_root` at `EXECUTION_PAYLOAD_GINDEX` (25).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CapellaLightClientHeader {
     pub beacon: BeaconBlockHeader,
     pub execution: ExecutionPayloadHeaderCapella,
@@ -104,20 +105,20 @@ pub struct CapellaLightClientHeader {
 ///
 /// This is the execution-layer block header embedded in the beacon block.
 /// Capella adds `withdrawals_root` compared to Bellatrix.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Encode, Decode, TreeHash)]
 pub struct ExecutionPayloadHeaderCapella {
     pub parent_hash: Root,
     pub fee_recipient: Address,
     pub state_root: Root,
     pub receipts_root: Root,
-    pub logs_bloom: Bloom,
+    pub logs_bloom: FixedVector<u8, BloomLen>,
     pub prev_randao: Root,
     pub block_number: u64,
     pub gas_limit: u64,
     pub gas_used: u64,
     pub timestamp: u64,
-    /// Variable-length extra data (`ByteList[32]`). Bound-enforced at construction.
-    pub extra_data: ExtraData,
+    /// `ByteList[32]` — the 32-byte bound is enforced by the `VariableList` type.
+    pub extra_data: VariableList<u8, MaxExtraData>,
     pub base_fee_per_gas: U256,
     pub block_hash: Root,
     pub transactions_root: Root,
@@ -125,60 +126,10 @@ pub struct ExecutionPayloadHeaderCapella {
 }
 
 impl ExecutionPayloadHeaderCapella {
-    /// Compute the SSZ `hash_tree_root` of this 15-field container.
-    ///
-    /// Uses `TreeHash::tree_hash_root()` for fields that implement it
-    /// (`u64`, `[u8; 32]`, `Bloom`, `ExtraData`). Two field types still
-    /// need custom hashing because `tree_hash` lacks impls:
-    ///
-    /// - `[u8; 20]` (Address): right-padded to 32 bytes
-    /// - `ruint::U256`: 32-byte little-endian value (single chunk)
+    /// SSZ `hash_tree_root` as a [`Root`] — thin wrapper over the derived
+    /// [`TreeHash`] impl (the field-by-field merkleization is now generated).
     pub fn hash_tree_root(&self) -> Root {
-        use tree_hash::TreeHash;
-
-        fn to_root(h: tree_hash::Hash256) -> Root {
-            let mut r = [0u8; 32];
-            r.copy_from_slice(h.as_bytes());
-            r
-        }
-
-        // [u8; 20]: right-padded to 32 bytes (no tree_hash impl exists).
-        fn address_root(addr: &[u8; 20]) -> Root {
-            let mut buf = [0u8; 32];
-            buf[..20].copy_from_slice(addr);
-            buf
-        }
-
-        // ruint::U256: 32-byte little-endian value (single chunk).
-        fn u256_root(v: &U256) -> Root {
-            v.to_le_bytes()
-        }
-
-        let field_roots: [Root; 15] = [
-            self.parent_hash,                            // 0: [u8; 32]
-            address_root(&self.fee_recipient),           // 1: [u8; 20]
-            self.state_root,                             // 2: [u8; 32]
-            self.receipts_root,                          // 3: [u8; 32]
-            to_root(self.logs_bloom.tree_hash_root()),   // 4: Bloom (TreeHash)
-            self.prev_randao,                            // 5: [u8; 32]
-            to_root(self.block_number.tree_hash_root()), // 6: u64
-            to_root(self.gas_limit.tree_hash_root()),    // 7: u64
-            to_root(self.gas_used.tree_hash_root()),     // 8: u64
-            to_root(self.timestamp.tree_hash_root()),    // 9: u64
-            to_root(self.extra_data.tree_hash_root()),   // 10: ExtraData (TreeHash)
-            u256_root(&self.base_fee_per_gas),           // 11: U256
-            self.block_hash,                             // 12: [u8; 32]
-            self.transactions_root,                      // 13: [u8; 32]
-            self.withdrawals_root,                       // 14: [u8; 32]
-        ];
-
-        // 15-field container → pad to 16 leaves and merkleize.
-        let mut leaf_bytes = [0u8; 32 * 16];
-        for (i, root) in field_roots.iter().enumerate() {
-            leaf_bytes[i * 32..(i + 1) * 32].copy_from_slice(root);
-        }
-
-        to_root(tree_hash::merkle_root(&leaf_bytes, 16))
+        self.tree_hash_root().0
     }
 }
 
@@ -186,7 +137,7 @@ impl ExecutionPayloadHeaderCapella {
 ///
 /// The execution branch length is unchanged: `EXECUTION_PAYLOAD_GINDEX` (25) is
 /// constant from Capella through Electra, so `floorlog2(25) = 4`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct DenebLightClientHeader {
     pub beacon: BeaconBlockHeader,
     pub execution: ExecutionPayloadHeaderDeneb,
@@ -199,20 +150,20 @@ pub struct DenebLightClientHeader {
 /// Adds `blob_gas_used` and `excess_blob_gas` to the Capella shape, increasing
 /// the SSZ container field count from 15 to 17. Merkleization pads to 32 leaves
 /// (next power of two ≥ 17), which differs from Capella's 16-leaf padding.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Encode, Decode, TreeHash)]
 pub struct ExecutionPayloadHeaderDeneb {
     pub parent_hash: Root,
     pub fee_recipient: Address,
     pub state_root: Root,
     pub receipts_root: Root,
-    pub logs_bloom: Bloom,
+    pub logs_bloom: FixedVector<u8, BloomLen>,
     pub prev_randao: Root,
     pub block_number: u64,
     pub gas_limit: u64,
     pub gas_used: u64,
     pub timestamp: u64,
-    /// Variable-length extra data (`ByteList[32]`). Bound-enforced at construction.
-    pub extra_data: ExtraData,
+    /// `ByteList[32]` — the 32-byte bound is enforced by the `VariableList` type.
+    pub extra_data: VariableList<u8, MaxExtraData>,
     pub base_fee_per_gas: U256,
     pub block_hash: Root,
     pub transactions_root: Root,
@@ -222,58 +173,10 @@ pub struct ExecutionPayloadHeaderDeneb {
 }
 
 impl ExecutionPayloadHeaderDeneb {
-    /// Compute the SSZ `hash_tree_root` of this 17-field container.
-    ///
-    /// Mirrors the Capella implementation — same custom hashing for `[u8; 20]`
-    /// (Address, right-padded to 32) and `ruint::U256` (32-byte little-endian
-    /// single chunk) — but with two extra `u64` field roots and 32-leaf padding
-    /// (next power of two ≥ 17).
+    /// SSZ `hash_tree_root` as a [`Root`] — thin wrapper over the derived
+    /// [`TreeHash`] impl.
     pub fn hash_tree_root(&self) -> Root {
-        use tree_hash::TreeHash;
-
-        fn to_root(h: tree_hash::Hash256) -> Root {
-            let mut r = [0u8; 32];
-            r.copy_from_slice(h.as_bytes());
-            r
-        }
-
-        fn address_root(addr: &[u8; 20]) -> Root {
-            let mut buf = [0u8; 32];
-            buf[..20].copy_from_slice(addr);
-            buf
-        }
-
-        fn u256_root(v: &U256) -> Root {
-            v.to_le_bytes()
-        }
-
-        let field_roots: [Root; 17] = [
-            self.parent_hash,                               // 0:  [u8; 32]
-            address_root(&self.fee_recipient),              // 1:  [u8; 20]
-            self.state_root,                                // 2:  [u8; 32]
-            self.receipts_root,                             // 3:  [u8; 32]
-            to_root(self.logs_bloom.tree_hash_root()),      // 4:  Bloom (TreeHash)
-            self.prev_randao,                               // 5:  [u8; 32]
-            to_root(self.block_number.tree_hash_root()),    // 6:  u64
-            to_root(self.gas_limit.tree_hash_root()),       // 7:  u64
-            to_root(self.gas_used.tree_hash_root()),        // 8:  u64
-            to_root(self.timestamp.tree_hash_root()),       // 9:  u64
-            to_root(self.extra_data.tree_hash_root()),      // 10: ExtraData (TreeHash)
-            u256_root(&self.base_fee_per_gas),              // 11: U256
-            self.block_hash,                                // 12: [u8; 32]
-            self.transactions_root,                         // 13: [u8; 32]
-            self.withdrawals_root,                          // 14: [u8; 32]
-            to_root(self.blob_gas_used.tree_hash_root()),   // 15: u64
-            to_root(self.excess_blob_gas.tree_hash_root()), // 16: u64
-        ];
-
-        // 17-field container → pad to 32 leaves and merkleize.
-        let mut leaf_bytes = [0u8; 32 * 32];
-        for (i, root) in field_roots.iter().enumerate() {
-            leaf_bytes[i * 32..(i + 1) * 32].copy_from_slice(root);
-        }
-
-        to_root(tree_hash::merkle_root(&leaf_bytes, 32))
+        self.tree_hash_root().0
     }
 }
 
@@ -491,7 +394,7 @@ impl SyncAggregate {
 /// Light client update containing all data needed for verification.
 ///
 /// Headers are fork-aware [`LightClientHeader`] values.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct LightClientUpdate {
     /// The header being attested to (fork-aware).
     pub attested_header: LightClientHeader,
@@ -609,7 +512,7 @@ impl LightClientUpdate {
 /// - The genesis validators root for the chain (used in signature domain computation)
 ///
 /// Corresponds to the `LightClientBootstrap` object in the Ethereum consensus specs.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct LightClientBootstrap {
     /// The trusted header (fork-aware).
     pub header: LightClientHeader,

--- a/src/types/primitives.rs
+++ b/src/types/primitives.rs
@@ -1,149 +1,25 @@
-use serde::{Deserialize, Serialize};
+//! Primitive type aliases shared across the crate.
+//!
+//! Execution-payload field types that need SSZ collection semantics
+//! (`fee_recipient`, `logs_bloom`, `extra_data`) live directly on the types in
+//! [`super::consensus`] as `ethereum_types` / `ssz_types` values, so they are no
+//! longer defined here.
 
 /// 32-byte hash type used throughout Ethereum
 pub type Hash = [u8; 32];
 
-/// Ethereum address (20 bytes)
-pub type Address = [u8; 20];
-
-/// 256-byte bloom filter for logs
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Bloom(pub [u8; 256]);
-
-impl Default for Bloom {
-    fn default() -> Self {
-        Bloom([0u8; 256])
-    }
-}
-
-impl Serialize for Bloom {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        hex::encode(self.0).serialize(serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for Bloom {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let hex_string: String = String::deserialize(deserializer)?;
-        let bytes =
-            hex::decode(hex_string.trim_start_matches("0x")).map_err(serde::de::Error::custom)?;
-        if bytes.len() != 256 {
-            return Err(serde::de::Error::custom("Bloom must be 256 bytes"));
-        }
-        let mut bloom = [0u8; 256];
-        bloom.copy_from_slice(&bytes);
-        Ok(Bloom(bloom))
-    }
-}
-
 /// Variable-length byte array
 pub type Bytes = Vec<u8>;
 
-// =============================================================================
-// SSZ-native TreeHash impls for consensus types
-// =============================================================================
-
-impl tree_hash::TreeHash for Bloom {
-    fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::Vector
-    }
-
-    fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
-        unreachable!("Bloom is not a basic type")
-    }
-
-    fn tree_hash_packing_factor() -> usize {
-        unreachable!("Bloom is not a basic type")
-    }
-
-    fn tree_hash_root(&self) -> tree_hash::Hash256 {
-        // ByteVector[256]: pack into 8 chunks of 32 bytes and merkleize.
-        tree_hash::merkle_root(&self.0, 8)
-    }
-}
-
-/// Bounded extra data field for execution payload headers.
-///
-/// SSZ type: `ByteList[MAX_EXTRA_DATA_BYTES]` where `MAX_EXTRA_DATA_BYTES = 32`.
-/// The bound is enforced at construction via [`ExtraData::try_new`]; the inner
-/// `Vec<u8>` is private, so no code path can bypass the check.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ExtraData(Vec<u8>);
-
-impl ExtraData {
-    /// Maximum length per the consensus spec (`MAX_EXTRA_DATA_BYTES`).
-    pub const MAX_BYTES: usize = 32;
-
-    /// Create from a byte vec, returning an error if it exceeds the bound.
-    pub fn try_new(data: Vec<u8>) -> crate::error::Result<Self> {
-        if data.len() > Self::MAX_BYTES {
-            return Err(crate::error::Error::InvalidInput(format!(
-                "extra_data length {} exceeds MAX_EXTRA_DATA_BYTES ({})",
-                data.len(),
-                Self::MAX_BYTES
-            )));
-        }
-        Ok(Self(data))
-    }
-
-    /// Create an empty ExtraData.
-    pub fn empty() -> Self {
-        Self(Vec::new())
-    }
-
-    /// Access the inner bytes.
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.0
-    }
-
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-}
-
-impl tree_hash::TreeHash for ExtraData {
-    fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::List
-    }
-
-    fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
-        unreachable!("ExtraData is not a basic type")
-    }
-
-    fn tree_hash_packing_factor() -> usize {
-        unreachable!("ExtraData is not a basic type")
-    }
-
-    fn tree_hash_root(&self) -> tree_hash::Hash256 {
-        // ByteList[32] hash: pack bytes into 1 chunk (right-padded to 32),
-        // then mix_in_length by hashing the 64-byte buffer
-        // [chunk (32 bytes) || length as LE u64 (8 bytes) || zeros (24 bytes)].
-        let mut chunk = [0u8; 32];
-        chunk[..self.0.len()].copy_from_slice(&self.0);
-        let mut mix = [0u8; 64];
-        mix[..32].copy_from_slice(&chunk);
-        mix[32..40].copy_from_slice(&(self.0.len() as u64).to_le_bytes());
-        tree_hash::merkle_root(&mix, 2)
-    }
-}
-
-/// 256-bit unsigned integer
-pub use ruint::aliases::U256;
+/// 256-bit unsigned integer. `ethereum_types::U256` carries the native SSZ
+/// `Encode`/`Decode`/`TreeHash` impls (unlike `ruint`), so execution headers
+/// derive their SSZ directly.
+pub use ethereum_types::U256;
 
 /// Beacon chain slot number
 pub type Slot = u64;
 
-/// Beacon chain epoch number  
+/// Beacon chain epoch number
 pub type Epoch = u64;
 
 /// Validator index in the beacon state
@@ -163,14 +39,3 @@ pub type Domain = [u8; 32];
 
 /// Fork version for different beacon chain forks
 pub type ForkVersion = [u8; 4];
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn extra_data_rejects_oversized() {
-        assert!(ExtraData::try_new(vec![0u8; 32]).is_ok());
-        assert!(ExtraData::try_new(vec![0u8; 33]).is_err());
-    }
-}

--- a/src/types/ssz.rs
+++ b/src/types/ssz.rs
@@ -10,7 +10,7 @@ use crate::types::consensus::{
     BeaconBlockHeader, ExecutionPayloadHeaderCapella, LightClientBootstrap, LightClientHeader,
     LightClientUpdate, SyncAggregate, SyncCommittee,
 };
-use crate::types::primitives::{Bloom, ExtraData, Root};
+use crate::types::primitives::Root;
 use ssz_rs::prelude::*;
 
 #[derive(Default, SimpleSerialize)]
@@ -127,32 +127,30 @@ impl RawExecutionPayloadHeader {
         let mut fee_recipient = [0u8; 20];
         fee_recipient.copy_from_slice(self.fee_recipient.as_ref());
 
-        let mut bloom_bytes = [0u8; 256];
-        bloom_bytes.copy_from_slice(self.logs_bloom.as_ref());
-
-        // Convert ssz_rs::U256 to ruint::U256 via LE bytes
+        // ssz_rs::U256 -> ethereum_types::U256 via LE bytes.
         let le_bytes = self.base_fee_per_gas.to_bytes_le();
         let mut u256_bytes = [0u8; 32];
         let len = le_bytes.len().min(32);
         u256_bytes[..len].copy_from_slice(&le_bytes[..len]);
-        let base_fee = ruint::aliases::U256::from_le_bytes(u256_bytes);
 
-        let extra_data_vec: Vec<u8> = self.extra_data.to_vec();
-        let extra_data = ExtraData::try_new(extra_data_vec)?;
+        let logs_bloom = ssz_types::FixedVector::new(self.logs_bloom.as_ref().to_vec())
+            .map_err(|e| crate::error::Error::Serialization(format!("logs_bloom: {e:?}")))?;
+        let extra_data = ssz_types::VariableList::new(self.extra_data.to_vec())
+            .map_err(|e| crate::error::Error::Serialization(format!("extra_data: {e:?}")))?;
 
         Ok(ExecutionPayloadHeaderCapella {
             parent_hash: node_to_root(&self.parent_hash),
-            fee_recipient,
+            fee_recipient: ethereum_types::H160(fee_recipient),
             state_root: node_to_root(&self.state_root),
             receipts_root: node_to_root(&self.receipts_root),
-            logs_bloom: Bloom(bloom_bytes),
+            logs_bloom,
             prev_randao: node_to_root(&self.prev_randao),
             block_number: self.block_number,
             gas_limit: self.gas_limit,
             gas_used: self.gas_used,
             timestamp: self.timestamp,
             extra_data,
-            base_fee_per_gas: base_fee,
+            base_fee_per_gas: ethereum_types::U256::from_little_endian(&u256_bytes),
             block_hash: node_to_root(&self.block_hash),
             transactions_root: node_to_root(&self.transactions_root),
             withdrawals_root: node_to_root(&self.withdrawals_root),


### PR DESCRIPTION
First step of the SSZ-native migration (issue #69, Path B).

## Summary
Make the execution payload headers **derive** their SSZ instead of hand-rolling it:

- `ExecutionPayloadHeader{Capella,Deneb}` now derive `Encode`/`Decode`/`TreeHash`. The hand-written 15-/17-field `hash_tree_root` (the crate's scariest consensus-critical code) is **deleted**, replaced by a thin `hash_tree_root() -> Root` wrapper over the derived `TreeHash`.
- Field types become ecosystem-native (the Lighthouse pattern): `fee_recipient → ethereum_types::Address`, `base_fee_per_gas → ethereum_types::U256`, `logs_bloom → FixedVector<u8, U256>`, `extra_data → VariableList<u8, U32>` (the 32-byte bound is now a type invariant, replacing `ExtraData::try_new`).
- **Drop `ruint`** entirely — it was used only for `base_fee_per_gas`, never for arithmetic; `ethereum_types::U256` (already transitive via `ethereum_ssz` + `tree_hash`) carries the native SSZ impls, so no newtype / hand-written impls.
- Remove the now-unused `Address`/`Bloom`/`ExtraData` from `primitives`.
- The mirror's converter builds the new field types (mirror + `ssz_rs` stay until later PRs migrate the remaining types).
- `Eq` dropped from the exec-header containment chain (`FixedVector` isn't `Eq`); `PartialEq` retained.

Adds `ssz_types 0.5` + `ethereum-types 0.14` (both drop-in with the pinned 0.5 SSZ stack; `ethereum-types` was already transitive).

## The proof
Spec tests green: the **derived** execution-header roots are byte-identical to the old hand-written merkleization against the official Capella fixtures. `clippy -D warnings` clean.

Part of the #69 arc; more type migrations to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)