### PR TITLE
refactor: SyncCommittee spec-sized + SSZ-native root (#69 PR2, resolves #21)

### DIFF
--- a/src/consensus/merkle.rs
+++ b/src/consensus/merkle.rs
@@ -13,40 +13,6 @@ use crate::error::{Error, Result};
 use crate::types::consensus::{LightClientHeader, SyncCommittee};
 use crate::types::primitives::Root;
 use crate::types::primitives::Slot;
-use tree_hash::TreeHash;
-
-/// Compute SSZ hash_tree_root for SyncCommittee using tree_hash library.
-///     (SyncCommittee is an SSZ Container:)
-fn compute_sync_committee_root(spec: &ChainSpec, committee: &SyncCommittee) -> Root {
-    let n = spec.sync_committee_size();
-
-    // Step 1 & 2: Compute hash_tree_root for each of the first N pubkeys directly into a single buffer.
-    let mut pubkeys_bytes = Vec::with_capacity(32 * n);
-    for pk in &committee.pubkeys.as_ref()[..n] {
-        pubkeys_bytes.extend_from_slice(pk.tree_hash_root().as_bytes());
-    }
-
-    // Merkleize pubkey roots as Vector[BLSPubkey, N]
-    let pubkeys_root_hash = tree_hash::merkle_root(&pubkeys_bytes, n);
-    let mut pubkeys_root = [0u8; 32];
-    pubkeys_root.copy_from_slice(pubkeys_root_hash.as_bytes());
-
-    // Step 3: Compute hash_tree_root for aggregate_pubkey
-    let aggregate_hash = committee.aggregate_pubkey.tree_hash_root();
-    let mut aggregate_root = [0u8; 32];
-    aggregate_root.copy_from_slice(aggregate_hash.as_bytes());
-
-    // Step 4: Container root = hash(pubkeys_root || aggregate_root)
-    // Use tree_hash::merkle_root on 64 bytes with 2 leaves
-    let mut container_data = [0u8; 64];
-    container_data[..32].copy_from_slice(&pubkeys_root);
-    container_data[32..].copy_from_slice(&aggregate_root);
-    let container_hash = tree_hash::merkle_root(&container_data, 2);
-
-    let mut result = [0u8; 32];
-    result.copy_from_slice(container_hash.as_bytes());
-    result
-}
 
 /// Verify that a sync committee is properly embedded in a beacon state root
 /// using the provided merkle branch proof (bootstrap verification).
@@ -59,7 +25,7 @@ pub(crate) fn verify_bootstrap_sync_committee(
     finalized_state_root: &Root,
     spec: &ChainSpec,
 ) -> Result<()> {
-    let sync_committee_root = compute_sync_committee_root(spec, sync_committee);
+    let sync_committee_root = sync_committee.hash_tree_root();
     let gindex = spec.current_sync_committee_gindex(header_slot);
 
     let is_valid = is_valid_merkle_branch(
@@ -86,7 +52,7 @@ pub(crate) fn verify_next_sync_committee(
     attested_state_root: &Root,
     spec: &ChainSpec,
 ) -> Result<()> {
-    let sync_committee_root = compute_sync_committee_root(spec, next_sync_committee);
+    let sync_committee_root = next_sync_committee.hash_tree_root();
     let gindex = spec.next_sync_committee_gindex(attested_header_slot);
 
     let is_valid = is_valid_merkle_branch(
@@ -331,47 +297,23 @@ mod tests {
         assert_ne!(result, result_reversed);
     }
 
-    #[test]
-    fn test_sync_committee_root_deterministic() {
-        let spec = ChainSpec::minimal();
-        let committee = SyncCommittee::new(
-            Box::new([[1u8; 48]; SyncCommittee::SYNC_COMMITTEE_SIZE]),
-            [2u8; 48],
-        );
-
-        let root1 = compute_sync_committee_root(&spec, &committee);
-        let root2 = compute_sync_committee_root(&spec, &committee);
-
-        assert_eq!(root1, root2);
-        assert_ne!(root1, [0u8; 32]);
+    /// Build a minimal-preset (32-key) committee for tests.
+    fn test_committee(pk: u8, agg: u8) -> SyncCommittee {
+        SyncCommittee::from_minimal_parts(vec![[pk; 48]; 32], [agg; 48]).unwrap()
     }
 
     #[test]
-    fn test_sync_committee_root_uses_declared_n() {
-        // Minimal uses N=32, mainnet uses N=SYNC_COMMITTEE_SIZE (512)
-        // Even with same data, roots should differ due to different N
-        let minimal_spec = ChainSpec::minimal();
-        let mainnet_spec = ChainSpec::mainnet();
-
-        let committee = SyncCommittee::new(
-            Box::new([[1u8; 48]; SyncCommittee::SYNC_COMMITTEE_SIZE]),
-            [2u8; 48],
-        );
-
-        let minimal_root = compute_sync_committee_root(&minimal_spec, &committee);
-        let mainnet_root = compute_sync_committee_root(&mainnet_spec, &committee);
-
-        // Roots should be different because minimal uses only first 32 pubkeys
-        assert_ne!(minimal_root, mainnet_root);
+    fn test_sync_committee_root_deterministic() {
+        let committee = test_committee(1, 2);
+        // Derived TreeHash: deterministic and non-zero.
+        assert_eq!(committee.hash_tree_root(), committee.hash_tree_root());
+        assert_ne!(committee.hash_tree_root(), [0u8; 32]);
     }
 
     #[test]
     fn test_bootstrap_verification_structure() {
         let spec = ChainSpec::minimal();
-        let sync_committee = SyncCommittee::new(
-            Box::new([[0u8; 48]; SyncCommittee::SYNC_COMMITTEE_SIZE]),
-            [0u8; 48],
-        );
+        let sync_committee = test_committee(0, 0);
 
         let empty_branch: Vec<Root> = vec![];
         let slot = 1000;
@@ -391,10 +333,7 @@ mod tests {
     #[test]
     fn test_next_sync_committee_verification_structure() {
         let spec = ChainSpec::minimal();
-        let sync_committee = SyncCommittee::new(
-            Box::new([[1u8; 48]; SyncCommittee::SYNC_COMMITTEE_SIZE]),
-            [2u8; 48],
-        );
+        let sync_committee = test_committee(1, 2);
 
         let empty_branch: Vec<Root> = vec![];
         let slot = 1000;
@@ -437,8 +376,8 @@ mod tests {
             .load_bootstrap()
             .expect("Failed to load bootstrap");
 
-        // Compute sync committee root using our hardened function
-        let computed_root = compute_sync_committee_root(&spec, &bootstrap.current_sync_committee);
+        // Compute sync committee root via the derived TreeHash.
+        let computed_root = bootstrap.current_sync_committee.hash_tree_root();
 
         // Verify against the state root using the branch
         let gindex = spec.current_sync_committee_gindex(bootstrap.header.slot());

--- a/src/consensus/processor.rs
+++ b/src/consensus/processor.rs
@@ -154,7 +154,7 @@ impl LightClientProcessor {
             committee,
             update.signature_slot,
             attested_header_root,
-            update.sync_aggregate.sync_committee_bits.as_ref(),
+            &update.sync_aggregate.sync_committee_bits,
             &update.sync_aggregate.sync_committee_signature,
             self.store.genesis_validators_root,
             &self.chain_spec,
@@ -308,8 +308,7 @@ mod tests {
     }
 
     fn create_test_sync_aggregate() -> SyncAggregate {
-        let sync_committee_bits = Box::new([true; SyncCommittee::SYNC_COMMITTEE_SIZE]);
-        SyncAggregate::new(sync_committee_bits, [1u8; 96])
+        SyncAggregate::new(vec![true; 32], [1u8; 96])
     }
 
     #[test]
@@ -416,10 +415,8 @@ mod tests {
         assert!(processor.store.next_sync_committee.is_none());
 
         // Inject a distinguishable "next" committee directly on the store
-        let next = SyncCommittee::new(
-            Box::new([[0xAA; 48]; SyncCommittee::SYNC_COMMITTEE_SIZE]),
-            [0xBB; 48],
-        );
+        let next =
+            SyncCommittee::from_minimal_parts(vec![[0xAA; 48]; 32], [0xBB; 48]).unwrap();
         processor.store.next_sync_committee = Some(next.clone());
 
         // Store period is still initial_period (finalized header not yet updated)
@@ -445,7 +442,8 @@ mod tests {
 
         // Assertions: store state is correct after rotation
         assert_eq!(
-            processor.store.current_sync_committee.aggregate_pubkey, [0xBB; 48],
+            processor.store.current_sync_committee.aggregate_pubkey().as_ref(),
+            &[0xBB; 48],
             "store current committee should be what was next"
         );
         assert!(

--- a/src/consensus/sync_committee.rs
+++ b/src/consensus/sync_committee.rs
@@ -111,12 +111,12 @@ pub(crate) fn learn_next_sync_committee_from_update(
 /// The caller supplies the correct committee (via `committee_for_slot`)
 /// and the `genesis_validators_root` from the store.
 ///
-/// TODO(#21): make sync committee bits spec-sized (use ChainSpec::sync_committee_size()).
+/// `sync_committee_bits` is spec-sized (its length must match the committee).
 pub(crate) fn verify_sync_aggregate(
     committee: &SyncCommittee,
     signature_slot: Slot,
     attested_header_root: Root,
-    sync_committee_bits: &[bool; 512],
+    sync_committee_bits: &[bool],
     sync_committee_signature: &BLSSignature,
     genesis_validators_root: Root,
     chain_spec: &ChainSpec,
@@ -372,32 +372,26 @@ mod tests {
         Ok(result)
     }
 
-    fn create_test_sync_committee() -> SyncCommittee {
-        let pubkeys = Box::new([[1u8; 48]; SyncCommittee::SYNC_COMMITTEE_SIZE]);
-        let aggregate_pubkey = [2u8; 48];
-        SyncCommittee::new(pubkeys, aggregate_pubkey)
+    fn test_committee(agg: u8) -> SyncCommittee {
+        SyncCommittee::from_minimal_parts(vec![[1u8; 48]; 32], [agg; 48]).unwrap()
     }
 
     #[test]
     fn test_committee_for_slot_selection() {
         let chain_spec = ChainSpec::mainnet();
-        let current = create_test_sync_committee();
-        let next = {
-            let mut c = create_test_sync_committee();
-            c.aggregate_pubkey = [3u8; 48]; // distinguishable
-            c
-        };
+        let current = test_committee(2);
+        let next = test_committee(3); // distinguishable by aggregate
 
         // Current period slots → current committee
         let got = committee_for_slot(0, 0, &current, Some(&next), &chain_spec).unwrap();
-        assert_eq!(got.aggregate_pubkey, current.aggregate_pubkey);
+        assert_eq!(got.aggregate_pubkey(), current.aggregate_pubkey());
 
         let got = committee_for_slot(8191, 0, &current, Some(&next), &chain_spec).unwrap();
-        assert_eq!(got.aggregate_pubkey, current.aggregate_pubkey);
+        assert_eq!(got.aggregate_pubkey(), current.aggregate_pubkey());
 
         // Next period slots → next committee (when known)
         let got = committee_for_slot(8192, 0, &current, Some(&next), &chain_spec).unwrap();
-        assert_eq!(got.aggregate_pubkey, next.aggregate_pubkey);
+        assert_eq!(got.aggregate_pubkey(), next.aggregate_pubkey());
 
         // Next period slots → error when next is None
         assert!(committee_for_slot(8192, 0, &current, None, &chain_spec).is_err());
@@ -789,13 +783,13 @@ mod tests {
     fn test_rejects_next_period_update_when_next_committee_unknown() {
         use crate::types::consensus::{BeaconBlockHeader, SyncAggregate};
 
-        let committee = create_test_sync_committee();
+        let committee = test_committee(2);
         let chain_spec = ChainSpec::mainnet();
         let finalized_period = 0;
 
         // Create an update with attested_header in period 1 (slot 8192 on mainnet)
         let attested_header = BeaconBlockHeader::new(8192, 42, [1u8; 32], [2u8; 32], [3u8; 32]);
-        let bits = Box::new([true; SyncCommittee::SYNC_COMMITTEE_SIZE]);
+        let bits = vec![true; 32];
         let sync_aggregate = SyncAggregate::new(bits, [0u8; 96]);
         let update = LightClientUpdate::new(attested_header, sync_aggregate, 8193)
             .with_next_sync_committee(committee, vec![[0u8; 32]; 5]);

--- a/src/types/consensus.rs
+++ b/src/types/consensus.rs
@@ -3,7 +3,7 @@ use crate::error::{Error, Result};
 use crate::types::primitives::{BLSPublicKey, BLSSignature, Epoch, Root, Slot, ValidatorIndex};
 use ethereum_types::{Address, U256};
 use ssz_derive::{Decode, Encode};
-use ssz_types::typenum::{U256 as BloomLen, U32 as MaxExtraData};
+use ssz_types::typenum::{U256 as BloomLen, U32, U48, U512};
 use ssz_types::{FixedVector, VariableList};
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
@@ -118,7 +118,7 @@ pub struct ExecutionPayloadHeaderCapella {
     pub gas_used: u64,
     pub timestamp: u64,
     /// `ByteList[32]` — the 32-byte bound is enforced by the `VariableList` type.
-    pub extra_data: VariableList<u8, MaxExtraData>,
+    pub extra_data: VariableList<u8, U32>,
     pub base_fee_per_gas: U256,
     pub block_hash: Root,
     pub transactions_root: Root,
@@ -163,7 +163,7 @@ pub struct ExecutionPayloadHeaderDeneb {
     pub gas_used: u64,
     pub timestamp: u64,
     /// `ByteList[32]` — the 32-byte bound is enforced by the `VariableList` type.
-    pub extra_data: VariableList<u8, MaxExtraData>,
+    pub extra_data: VariableList<u8, U32>,
     pub base_fee_per_gas: U256,
     pub block_hash: Root,
     pub transactions_root: Root,
@@ -291,89 +291,130 @@ impl LightClientHeader {
 // SyncCommittee
 // =============================================================================
 
-/// Sync committee with 512 validators
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// A single BLS public key as SSZ bytes (`Vector[byte, 48]`).
+pub type PubkeyBytes = FixedVector<u8, U48>;
+
+/// Sync committee: a spec-sized list of BLS pubkeys plus the aggregate.
+///
+/// The list length *is* the committee size (32 minimal / 512 mainnet), so there
+/// is no zero-padding (#21). The SSZ size — which the network preset fixes and
+/// [`ChainSpec`] owns — is not carried on the value; the root is computed by
+/// dispatching on the list length to a size-specific SSZ-native helper below.
+#[derive(Debug, Clone, PartialEq)]
 pub struct SyncCommittee {
-    /// 512 BLS public keys (heap-allocated to avoid stack overflow)
-    pub pubkeys: Box<[BLSPublicKey; 512]>,
-    /// Aggregate public key for the committee
-    pub aggregate_pubkey: BLSPublicKey,
+    pubkeys: Vec<PubkeyBytes>,
+    aggregate_pubkey: PubkeyBytes,
+}
+
+// Size-specific SSZ-native views used only to derive the committee root
+// (`Vector[pubkey, N]`); the library does the merkleization, not hand-rolled.
+#[derive(TreeHash)]
+struct CommitteeRoot512 {
+    pubkeys: FixedVector<PubkeyBytes, U512>,
+    aggregate_pubkey: PubkeyBytes,
+}
+#[derive(TreeHash)]
+struct CommitteeRoot32 {
+    pubkeys: FixedVector<PubkeyBytes, U32>,
+    aggregate_pubkey: PubkeyBytes,
 }
 
 impl SyncCommittee {
-    pub const SYNC_COMMITTEE_SIZE: usize = 512;
-
-    pub fn new(pubkeys: Box<[BLSPublicKey; 512]>, aggregate_pubkey: BLSPublicKey) -> Self {
-        Self {
-            pubkeys,
-            aggregate_pubkey,
+    /// SSZ `hash_tree_root`, dispatched on the (spec-sized) committee length.
+    pub fn hash_tree_root(&self) -> Root {
+        let agg = self.aggregate_pubkey.clone();
+        match self.pubkeys.len() {
+            512 => CommitteeRoot512 {
+                pubkeys: FixedVector::new(self.pubkeys.clone()).expect("len checked"),
+                aggregate_pubkey: agg,
+            }
+            .tree_hash_root()
+            .0,
+            32 => CommitteeRoot32 {
+                pubkeys: FixedVector::new(self.pubkeys.clone()).expect("len checked"),
+                aggregate_pubkey: agg,
+            }
+            .tree_hash_root()
+            .0,
+            n => unreachable!("sync committee is 32 or 512 members, got {n}"),
         }
     }
 
-    /// TODO(#21): delete once SyncCommittee is spec-sized (no zero-padding).
-    ///
-    /// Count the number of actual (non-zero) pubkeys in the committee
-    /// This handles both minimal preset (32 keys) and mainnet (512 keys)
-    pub fn actual_committee_size(&self) -> usize {
-        self.pubkeys
-            .iter()
-            .filter(|pk| !pk.iter().all(|&b| b == 0))
-            .count()
+    /// The committee members (spec-sized: 32 or 512, no padding).
+    pub fn pubkeys(&self) -> &[PubkeyBytes] {
+        &self.pubkeys
     }
 
-    /// Check if we have the minimum threshold for a valid sync committee signature
-    /// Uses actual committee size (non-zero pubkeys) rather than hardcoded 512
+    pub fn aggregate_pubkey(&self) -> &PubkeyBytes {
+        &self.aggregate_pubkey
+    }
+
+    /// Number of committee members (spec-sized; no padding).
+    pub fn len(&self) -> usize {
+        self.pubkeys.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.pubkeys.is_empty()
+    }
+
+    /// 2/3 supermajority over the spec-sized committee.
     pub fn has_supermajority_participation(&self, participation_bits: &[bool]) -> bool {
-        if participation_bits.len() != Self::SYNC_COMMITTEE_SIZE {
+        if participation_bits.len() != self.len() {
             return false;
         }
-
-        let participant_count = participation_bits.iter().filter(|&&bit| bit).count();
-        let actual_size = self.actual_committee_size();
-
-        // Need 2/3+ of actual committee members, not the padded size
-        participant_count >= (actual_size * 2 / 3)
+        let participants = participation_bits.iter().filter(|&&b| b).count();
+        participants >= (self.len() * 2 / 3)
     }
 
-    /// Get participating public keys based on participation bits
-    /// Filters out zero pubkeys to handle minimal preset (32 keys) vs mainnet (512 keys)
+    /// Bit-selected participating pubkeys as raw 48-byte keys (for BLS).
     pub fn participating_pubkeys(&self, participation_bits: &[bool]) -> Result<Vec<BLSPublicKey>> {
-        if participation_bits.len() != Self::SYNC_COMMITTEE_SIZE {
+        if participation_bits.len() != self.len() {
             return Err(Error::InvalidInput(
                 "Participation bits length mismatch".to_string(),
             ));
         }
-
-        let mut participating_pubkeys = Vec::new();
+        let mut out = Vec::new();
         for (i, &bit) in participation_bits.iter().enumerate() {
             if bit {
-                let pubkey = self.pubkeys[i];
-                // Filter out zero pubkeys (padding for minimal preset)
-                if !pubkey.iter().all(|&b| b == 0) {
-                    participating_pubkeys.push(pubkey);
-                }
+                let mut key = [0u8; 48];
+                key.copy_from_slice(&self.pubkeys[i]);
+                out.push(key);
             }
         }
+        Ok(out)
+    }
 
-        Ok(participating_pubkeys)
+    /// Build a minimal-preset (32-key) committee from raw pubkey bytes.
+    /// The fixture decoder uses this; mainnet committee decode is not yet wired.
+    pub(crate) fn from_minimal_parts(
+        pubkeys: Vec<BLSPublicKey>,
+        aggregate_pubkey: BLSPublicKey,
+    ) -> Result<Self> {
+        Ok(SyncCommittee {
+            pubkeys: pubkeys
+                .into_iter()
+                .map(|pk| PubkeyBytes::new(pk.to_vec()).expect("48-byte pubkey"))
+                .collect(),
+            aggregate_pubkey: PubkeyBytes::new(aggregate_pubkey.to_vec()).expect("48-byte pubkey"),
+        })
     }
 }
 
-/// Sync aggregate data for light client updates
-/// Note: Cannot derive SSZ Decode because [bool; 512] and [u8; 96] aren't supported by ethereum_ssz
+/// Sync aggregate data for light client updates.
+///
+/// `sync_committee_bits` is spec-sized (32 or 512, no padding) — one bit per
+/// committee member. The aggregate is never `hash_tree_root`'d, so it needs no
+/// SSZ derive; it's decoded off the wire and used for participation + BLS.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SyncAggregate {
-    /// Participation bits for 512 sync committee members (heap-allocated to avoid stack overflow)
-    pub sync_committee_bits: Box<[bool; 512]>,
+    pub sync_committee_bits: Vec<bool>,
     /// BLS aggregate signature
     pub sync_committee_signature: BLSSignature,
 }
 
 impl SyncAggregate {
-    pub fn new(
-        sync_committee_bits: Box<[bool; 512]>,
-        sync_committee_signature: BLSSignature,
-    ) -> Self {
+    pub fn new(sync_committee_bits: Vec<bool>, sync_committee_signature: BLSSignature) -> Self {
         Self {
             sync_committee_bits,
             sync_committee_signature,
@@ -645,38 +686,32 @@ mod tests {
     }
 
     fn create_test_sync_committee() -> SyncCommittee {
-        let pubkeys = Box::new([[1u8; 48]; 512]);
-        let aggregate_pubkey = [2u8; 48];
-        SyncCommittee::new(pubkeys, aggregate_pubkey)
+        SyncCommittee::from_minimal_parts(vec![[1u8; 48]; 32], [2u8; 48]).unwrap()
     }
 
     #[test]
     fn test_sync_committee_supermajority() {
         let committee = create_test_sync_committee();
+        let threshold = 32 * 2 / 3; // 21 of 32
 
-        // Test with exactly 2/3 participation (341 out of 512)
-        let mut participation = [false; 512];
-        for i in 0..341 {
-            participation[i] = true;
-        }
+        // Exactly 2/3 passes.
+        let mut participation = vec![false; 32];
+        participation.iter_mut().take(threshold).for_each(|p| *p = true);
         assert!(committee.has_supermajority_participation(&participation));
 
-        // Test with less than 2/3 participation
-        let mut participation = [false; 512];
-        for i in 0..340 {
-            participation[i] = true;
-        }
+        // One below 2/3 fails.
+        let mut participation = vec![false; 32];
+        participation.iter_mut().take(threshold - 1).for_each(|p| *p = true);
         assert!(!committee.has_supermajority_participation(&participation));
 
-        // Test with full participation
-        let participation = [true; 512];
-        assert!(committee.has_supermajority_participation(&participation));
+        // Full participation passes.
+        assert!(committee.has_supermajority_participation(&vec![true; 32]));
     }
 
     #[test]
     fn test_light_client_update_validation() {
         let attested_header = create_test_beacon_header();
-        let sync_committee_bits = Box::new([true; 512]); // Full participation
+        let sync_committee_bits = vec![true; 32]; // Full participation
         let sync_committee_signature = [1u8; 96];
         let sync_aggregate = SyncAggregate::new(sync_committee_bits, sync_committee_signature);
 

--- a/src/types/ssz.rs
+++ b/src/types/ssz.rs
@@ -54,20 +54,23 @@ pub(crate) struct RawSyncCommittee {
 
 impl RawSyncCommittee {
     pub(crate) fn into_sync_committee(self) -> SyncCommittee {
-        // Minimal fixtures hold 32 pubkeys; production is mainnet-sized (512).
-        // Padding is inert: root + signature checks read only pubkeys[..N] (N from ChainSpec).
-        // The 32-element count is guaranteed by the SSZ `Vector<_, 32>` decode.
-        let mut pubkeys_array = Box::new([[0u8; 48]; 512]);
-        for (i, pk) in self.pubkeys.iter().enumerate() {
-            let mut key = [0u8; 48];
-            key.copy_from_slice(pk.as_ref());
-            pubkeys_array[i] = key;
-        }
+        // Minimal fixtures hold exactly 32 pubkeys (guaranteed by the SSZ
+        // `Vector<_, 32>` decode) — the spec-sized minimal committee, no padding.
+        let pubkeys: Vec<[u8; 48]> = self
+            .pubkeys
+            .iter()
+            .map(|pk| {
+                let mut key = [0u8; 48];
+                key.copy_from_slice(pk.as_ref());
+                key
+            })
+            .collect();
 
         let mut aggregate = [0u8; 48];
         aggregate.copy_from_slice(self.aggregate_pubkey.as_ref());
 
-        SyncCommittee::new(pubkeys_array, aggregate)
+        SyncCommittee::from_minimal_parts(pubkeys, aggregate)
+            .expect("minimal fixture committee is 32 valid pubkeys")
     }
 }
 
@@ -79,15 +82,13 @@ struct RawSyncAggregate {
 
 impl RawSyncAggregate {
     fn into_sync_aggregate(self) -> SyncAggregate {
-        let mut bits_array = Box::new([false; 512]);
-        for (i, bit) in self.sync_committee_bits.iter().enumerate() {
-            bits_array[i] = *bit;
-        }
+        // Spec-sized bits (32 for minimal fixtures), no padding.
+        let bits: Vec<bool> = self.sync_committee_bits.iter().map(|b| *b).collect();
 
         let mut signature = [0u8; 96];
         signature.copy_from_slice(self.sync_committee_signature.as_ref());
 
-        SyncAggregate::new(bits_array, signature)
+        SyncAggregate::new(bits, signature)
     }
 }
 
@@ -242,7 +243,7 @@ fn assemble_update(
 ) -> LightClientUpdate {
     let has_finality = finalized_header.is_some();
     let has_sync_committee = !sync_committee
-        .pubkeys
+        .pubkeys()
         .iter()
         .all(|pk| pk.iter().all(|&b| b == 0));
 


### PR DESCRIPTION
Second step of the SSZ-native migration (issue #69, Path B), and it resolves **#21**.

## Summary
`SyncCommittee` was a hardcoded `Box<[BLSPublicKey; 512]>` with the minimal preset (32 keys) **zero-padded up to 512**, plus a hand-written size-aware `hash_tree_root`. That padding *is* #21. Replaced with a single spec-sized type:

```rust
struct SyncCommittee { pubkeys: Vec<PubkeyBytes>, aggregate_pubkey: PubkeyBytes }
```

- The list length **is** the committee size (32 or 512) — no padding.
- The root is computed by dispatching on the length to a size-specific SSZ-native helper (`CommitteeRoot512` / `CommitteeRoot32`, `Vector[pubkey, N]`) that **derives** its `TreeHash` — the library merkleizes, not hand-rolled code.
- **Design note:** committee size is a *network* constant that `ChainSpec` already owns, so it's deliberately not carried on the committee value (no per-value preset tag / enum). The committee is plain data; its length reflects the network.

## Details
- Deleted the hand-written `compute_sync_committee_root` in `merkle.rs` → now `committee.hash_tree_root()`.
- Deleted the #21 padding machinery (`actual_committee_size`, zero-pubkey filtering). Accessors keep BLS on raw `[u8; 48]`.
- `SyncAggregate.sync_committee_bits`: `Box<[bool; 512]>` → `Vec<bool>` (spec-sized; never `hash_tree_root`'d, so no SSZ derive).
- `verify_sync_aggregate` takes `&[bool]` instead of `&[bool; 512]`.
- The mirror builds a 32-key committee (no pad). Mainnet *committee* decode stays unwired (pre-existing gap; mirror is minimal-only) — not a regression.

## The proof
Spec tests green: the derived minimal committee root matches the official fixtures (sync-committee branch verification passes); BLS verification unaffected. `clippy -D warnings` clean.

Resolves #21. Part of the #69 arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)