### PR TITLE
refactor: drop ssz_rs — one SSZ implementation (closes #69)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ ethereum_ssz = "0.5"        # SSZ encoding/decoding
 ethereum_ssz_derive = "0.5" # SSZ derive macros
 tree_hash = "0.5"           # TreeHash trait and merkle root computation
 tree_hash_derive = "0.5"    # Derive macros for TreeHash
-ssz_rs = "0.9"              # SSZ decode of wire bytes into public types (see README "SSZ libraries", #69)
 
 # Error handling
 thiserror = "1.0"
@@ -50,7 +49,6 @@ optional = true
 serde_yaml = "0.9"  # For parsing test metadata (meta.yaml, steps.yaml)
 walkdir = "2.4"     # For recursively finding BLS test cases
 snap = "1.1"        # For decompressing .ssz_snappy files
-ssz_rs = "0.9"      # For test vector encoding (test vectors generated with ssz_rs)
 
 [profile.release]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -98,13 +98,18 @@ For local testnets or devnets, use `ChainSpecConfig` with `ChainSpec::try_from_c
   - `512` for mainnet
 - SSZ tree layouts and generalized indices are not fully generic inputs; proof paths are implemented explicitly for each supported fork
 
-### SSZ libraries
-The crate deliberately uses **two** SSZ implementations, each for a different job:
+### SSZ
+The crate uses a single SSZ implementation — the Sigma Prime / Lighthouse
+stack: **`ethereum_ssz`** (encode/decode) + **`ssz_types`** (length-bounded
+collections: `FixedVector`, `VariableList`, `BitVector`) + **`tree_hash`**
+(`hash_tree_root`). Public types carry their SSZ traits by deriving them
+(`#[derive(Encode, Decode, TreeHash)]`), so there is no hand-written
+merkleization and no second SSZ library.
 
-- **`ethereum_ssz`** (+ `tree_hash`) — for the production types' encoding and `hash_tree_root` (the verification path). It keeps the public types ergonomic by using plain arrays (`[u8; 48]`, not `FixedVector<u8, U48>`) plus a few hand-written `hash_tree_root` impls, rather than pulling in `ssz_types`' typenum-generic collections.
-- **`ssz_rs`** — for **decoding** wire/fixture bytes into those types (currently behind the `test-utils` feature). It bundles all the SSZ container types (fixed vectors, bitvectors, bounded lists, `U256`) in one crate, so the decode path needs neither `ssz_types` nor hand-written decoders.
-
-This is a choice, not an oversight. The two cross-check each other: bytes are decoded with `ssz_rs`, then `hash_tree_root`'d with `ethereum_ssz` and compared against the fixtures' expected roots — a disagreement fails the tests. Consolidating onto one implementation is possible but would mean adopting the `ssz_types` machinery both layers intentionally avoid, so it is not currently planned.
+The one bespoke SSZ code is the wire-decode adapter in `src/types/ssz.rs`: it
+decodes fork-specific wire layouts and adapts them to the ergonomic public
+types (fork-enum headers, `Option` fields, the spec-sized sync committee) — the
+parts that cannot be a plain derive. It uses `ethereum_ssz` like everything else.
 
 ## Testing
 This library is end-to-end tested against official Ethereum Consensus light client spec tests for Altair, Bellatrix, and Capella hardforks.  Tests exercise the full verification flow through the public API:

--- a/src/types/ssz.rs
+++ b/src/types/ssz.rs
@@ -1,56 +1,24 @@
-//! SSZ wire types and their conversions into the public light client types.
+//! SSZ wire decode for the light client types.
 //!
-//! These `Raw*` structs mirror the on-the-wire SSZ layout and decode via
-//! `ethereum_ssz` (the crate's single SSZ implementation). The converters adapt
-//! them to the ergonomic public types — fork-enum headers, `Option` fields, and
-//! the spec-sized committee — applying the spec's optional-field rules.
+//! Most public types decode themselves (`#[derive(Decode)]`): `BeaconBlockHeader`
+//! and `CapellaLightClientHeader` are used directly as wire fields. What remains
+//! here is the irreducible adapter: fork-dispatched wrapping of headers into the
+//! [`LightClientHeader`] enum, the spec-sized sync committee / aggregate (which
+//! can't be a plain derive), and the spec's optional-field collapse.
 //!
 //! The mirror is minimal-preset only: it decodes 32-key committees. Mainnet
 //! committee decode is not yet wired.
 
 use crate::config::Fork;
 use crate::types::consensus::{
-    BeaconBlockHeader, ExecutionPayloadHeaderCapella, LightClientBootstrap, LightClientHeader,
+    BeaconBlockHeader, CapellaLightClientHeader, LightClientBootstrap, LightClientHeader,
     LightClientUpdate, SyncAggregate, SyncCommittee,
 };
 use crate::types::primitives::Root;
 use ssz::Decode as _;
 use ssz_derive::Decode;
-use ssz_types::typenum::{U20, U256 as BloomBytes, U32, U4, U48, U5, U6, U96};
-use ssz_types::{BitVector, FixedVector, VariableList};
-
-#[derive(Decode)]
-struct RawBeaconBlockHeader {
-    slot: u64,
-    proposer_index: u64,
-    parent_root: Root,
-    state_root: Root,
-    body_root: Root,
-}
-
-impl RawBeaconBlockHeader {
-    fn into_beacon_block_header(self) -> BeaconBlockHeader {
-        BeaconBlockHeader::new(
-            self.slot,
-            self.proposer_index,
-            self.parent_root,
-            self.state_root,
-            self.body_root,
-        )
-    }
-}
-
-#[derive(Decode)]
-pub(crate) struct RawLightClientHeader {
-    beacon: RawBeaconBlockHeader,
-}
-
-#[derive(Decode)]
-pub(crate) struct RawLightClientBootstrap {
-    pub(crate) header: RawLightClientHeader,
-    pub(crate) current_sync_committee: RawSyncCommittee,
-    pub(crate) current_sync_committee_branch: FixedVector<Root, U5>,
-}
+use ssz_types::typenum::{U32, U48, U5, U6, U96};
+use ssz_types::{BitVector, FixedVector};
 
 #[derive(Decode)]
 pub(crate) struct RawSyncCommittee {
@@ -59,7 +27,7 @@ pub(crate) struct RawSyncCommittee {
 }
 
 impl RawSyncCommittee {
-    pub(crate) fn into_sync_committee(self) -> SyncCommittee {
+    fn into_sync_committee(self) -> SyncCommittee {
         // Minimal fixtures hold exactly 32 pubkeys (SSZ `Vector<_, 32>` decode) —
         // the spec-sized minimal committee, no padding.
         let pubkeys: Vec<[u8; 48]> = self
@@ -98,111 +66,54 @@ impl RawSyncAggregate {
     }
 }
 
-// Altair/Bellatrix update (beacon-only headers)
+// Beacon-only (Altair/Bellatrix): the header is a `BeaconBlockHeader` on the wire
+// (the 1-field LightClientHeader wrapper is serialization-transparent).
 #[derive(Decode)]
-pub(crate) struct RawLightClientUpdate {
-    attested_header: RawLightClientHeader,
+struct RawLightClientUpdate {
+    attested_header: BeaconBlockHeader,
     next_sync_committee: RawSyncCommittee,
     next_sync_committee_branch: FixedVector<Root, U5>,
-    finalized_header: RawLightClientHeader,
+    finalized_header: BeaconBlockHeader,
     finality_branch: FixedVector<Root, U6>,
     sync_aggregate: RawSyncAggregate,
     signature_slot: u64,
 }
 
 #[derive(Decode)]
-struct RawExecutionPayloadHeader {
-    parent_hash: Root,
-    fee_recipient: FixedVector<u8, U20>,
-    state_root: Root,
-    receipts_root: Root,
-    logs_bloom: FixedVector<u8, BloomBytes>,
-    prev_randao: Root,
-    block_number: u64,
-    gas_limit: u64,
-    gas_used: u64,
-    timestamp: u64,
-    extra_data: VariableList<u8, U32>,
-    base_fee_per_gas: ethereum_types::U256,
-    block_hash: Root,
-    transactions_root: Root,
-    withdrawals_root: Root,
+struct RawLightClientBootstrap {
+    header: BeaconBlockHeader,
+    current_sync_committee: RawSyncCommittee,
+    current_sync_committee_branch: FixedVector<Root, U5>,
 }
 
-impl RawExecutionPayloadHeader {
-    fn into_execution_payload_header(self) -> ExecutionPayloadHeaderCapella {
-        let mut fee_recipient = [0u8; 20];
-        fee_recipient.copy_from_slice(self.fee_recipient.as_ref());
-
-        ExecutionPayloadHeaderCapella {
-            parent_hash: self.parent_hash,
-            fee_recipient: ethereum_types::H160(fee_recipient),
-            state_root: self.state_root,
-            receipts_root: self.receipts_root,
-            logs_bloom: self.logs_bloom,
-            prev_randao: self.prev_randao,
-            block_number: self.block_number,
-            gas_limit: self.gas_limit,
-            gas_used: self.gas_used,
-            timestamp: self.timestamp,
-            extra_data: self.extra_data,
-            base_fee_per_gas: self.base_fee_per_gas,
-            block_hash: self.block_hash,
-            transactions_root: self.transactions_root,
-            withdrawals_root: self.withdrawals_root,
-        }
-    }
-}
-
+// Capella+: the header is the public `CapellaLightClientHeader` container.
 #[derive(Decode)]
-pub(crate) struct RawCapellaLightClientHeader {
-    beacon: RawBeaconBlockHeader,
-    execution: RawExecutionPayloadHeader,
-    execution_branch: FixedVector<Root, U4>,
-}
-
-#[derive(Decode)]
-pub(crate) struct RawCapellaLightClientBootstrap {
-    pub(crate) header: RawCapellaLightClientHeader,
-    pub(crate) current_sync_committee: RawSyncCommittee,
-    pub(crate) current_sync_committee_branch: FixedVector<Root, U5>,
-}
-
-#[derive(Decode)]
-pub(crate) struct RawCapellaLightClientUpdate {
-    attested_header: RawCapellaLightClientHeader,
+struct RawCapellaLightClientUpdate {
+    attested_header: CapellaLightClientHeader,
     next_sync_committee: RawSyncCommittee,
     next_sync_committee_branch: FixedVector<Root, U5>,
-    finalized_header: RawCapellaLightClientHeader,
+    finalized_header: CapellaLightClientHeader,
     finality_branch: FixedVector<Root, U6>,
     sync_aggregate: RawSyncAggregate,
     signature_slot: u64,
 }
 
-/// Convert a beacon-only fixture header into the matching production
-/// `LightClientHeader` variant. Only valid for Altair/Bellatrix.
-pub(crate) fn raw_beacon_only_header_to_pub(
-    fork: Fork,
-    raw: RawLightClientHeader,
-) -> LightClientHeader {
-    let beacon = raw.beacon.into_beacon_block_header();
+#[derive(Decode)]
+struct RawCapellaLightClientBootstrap {
+    header: CapellaLightClientHeader,
+    current_sync_committee: RawSyncCommittee,
+    current_sync_committee_branch: FixedVector<Root, U5>,
+}
+
+/// Wrap a decoded beacon header into the fork's `LightClientHeader` variant.
+fn wrap_beacon_only(fork: Fork, beacon: BeaconBlockHeader) -> LightClientHeader {
     match fork {
         Fork::Altair => LightClientHeader::altair(beacon),
         Fork::Bellatrix => LightClientHeader::bellatrix(beacon),
         Fork::Capella | Fork::Deneb | Fork::Electra => {
-            unreachable!("beacon-only converter called for {fork:?}")
+            unreachable!("beacon-only header for {fork:?}")
         }
     }
-}
-
-pub(crate) fn raw_capella_header_to_pub(raw: RawCapellaLightClientHeader) -> LightClientHeader {
-    let beacon = raw.beacon.into_beacon_block_header();
-    let execution = raw.execution.into_execution_payload_header();
-    let mut execution_branch = [[0u8; 32]; 4];
-    for (i, node) in raw.execution_branch.iter().enumerate() {
-        execution_branch[i] = *node;
-    }
-    LightClientHeader::capella(beacon, execution, execution_branch)
 }
 
 /// Assemble a `LightClientUpdate` from converted parts, applying the spec's
@@ -243,55 +154,33 @@ fn assemble_update(
     }
 }
 
-pub(crate) fn raw_beacon_only_update_to_pub(
-    fork: Fork,
-    raw: RawLightClientUpdate,
-) -> LightClientUpdate {
-    let sync_committee = raw.next_sync_committee.into_sync_committee();
-    let sync_aggregate = raw.sync_aggregate.into_sync_aggregate();
-    let finality_branch = raw.finality_branch.to_vec();
-    let next_sync_committee_branch = raw.next_sync_committee_branch.to_vec();
-
+fn raw_beacon_only_update_to_pub(fork: Fork, raw: RawLightClientUpdate) -> LightClientUpdate {
     // A default (slot-0) finalized header means the update carries no finality.
-    let finalized_header = if raw.finalized_header.beacon.slot != 0 {
-        Some(raw_beacon_only_header_to_pub(fork, raw.finalized_header))
-    } else {
-        None
-    };
-    let attested_header = raw_beacon_only_header_to_pub(fork, raw.attested_header);
+    let finalized_header =
+        (raw.finalized_header.slot != 0).then_some(wrap_beacon_only(fork, raw.finalized_header));
 
     assemble_update(
-        attested_header,
+        wrap_beacon_only(fork, raw.attested_header),
         finalized_header,
-        finality_branch,
-        sync_committee,
-        next_sync_committee_branch,
-        sync_aggregate,
+        raw.finality_branch.to_vec(),
+        raw.next_sync_committee.into_sync_committee(),
+        raw.next_sync_committee_branch.to_vec(),
+        raw.sync_aggregate.into_sync_aggregate(),
         raw.signature_slot,
     )
 }
 
-pub(crate) fn raw_capella_update_to_pub(raw: RawCapellaLightClientUpdate) -> LightClientUpdate {
-    let sync_committee = raw.next_sync_committee.into_sync_committee();
-    let sync_aggregate = raw.sync_aggregate.into_sync_aggregate();
-    let finality_branch = raw.finality_branch.to_vec();
-    let next_sync_committee_branch = raw.next_sync_committee_branch.to_vec();
-
-    // A default (slot-0) finalized header means the update carries no finality.
-    let finalized_header = if raw.finalized_header.beacon.slot != 0 {
-        Some(raw_capella_header_to_pub(raw.finalized_header))
-    } else {
-        None
-    };
-    let attested_header = raw_capella_header_to_pub(raw.attested_header);
+fn raw_capella_update_to_pub(raw: RawCapellaLightClientUpdate) -> LightClientUpdate {
+    let finalized_header = (raw.finalized_header.beacon.slot != 0)
+        .then_some(LightClientHeader::Capella(raw.finalized_header));
 
     assemble_update(
-        attested_header,
+        LightClientHeader::Capella(raw.attested_header),
         finalized_header,
-        finality_branch,
-        sync_committee,
-        next_sync_committee_branch,
-        sync_aggregate,
+        raw.finality_branch.to_vec(),
+        raw.next_sync_committee.into_sync_committee(),
+        raw.next_sync_committee_branch.to_vec(),
+        raw.sync_aggregate.into_sync_aggregate(),
         raw.signature_slot,
     )
 }
@@ -321,25 +210,19 @@ pub(crate) fn decode_bootstrap(
     match fork {
         Fork::Altair | Fork::Bellatrix => {
             let raw = RawLightClientBootstrap::from_ssz_bytes(bytes).map_err(decode_err)?;
-            let sync_committee = raw.current_sync_committee.into_sync_committee();
-            let branch = raw.current_sync_committee_branch.to_vec();
-            let header = raw_beacon_only_header_to_pub(fork, raw.header);
             Ok(LightClientBootstrap::from_header(
-                header,
-                sync_committee,
-                branch,
+                wrap_beacon_only(fork, raw.header),
+                raw.current_sync_committee.into_sync_committee(),
+                raw.current_sync_committee_branch.to_vec(),
                 genesis_validators_root,
             ))
         }
         Fork::Capella => {
             let raw = RawCapellaLightClientBootstrap::from_ssz_bytes(bytes).map_err(decode_err)?;
-            let sync_committee = raw.current_sync_committee.into_sync_committee();
-            let branch = raw.current_sync_committee_branch.to_vec();
-            let header = raw_capella_header_to_pub(raw.header);
             Ok(LightClientBootstrap::from_header(
-                header,
-                sync_committee,
-                branch,
+                LightClientHeader::Capella(raw.header),
+                raw.current_sync_committee.into_sync_committee(),
+                raw.current_sync_committee_branch.to_vec(),
                 genesis_validators_root,
             ))
         }

--- a/src/types/ssz.rs
+++ b/src/types/ssz.rs
@@ -1,9 +1,12 @@
-//! Raw SSZ wire types and their conversions into the public light client types.
+//! SSZ wire types and their conversions into the public light client types.
 //!
-//! These `Raw*` structs mirror the on-the-wire SSZ layout (decoded with
-//! `ssz_rs`); the converters adapt them to the ergonomic public types. See the
-//! crate README ("SSZ libraries") for why decode lives on `ssz_rs`, and issue
-//! #69 for the eventual SSZ-native consolidation.
+//! These `Raw*` structs mirror the on-the-wire SSZ layout and decode via
+//! `ethereum_ssz` (the crate's single SSZ implementation). The converters adapt
+//! them to the ergonomic public types — fork-enum headers, `Option` fields, and
+//! the spec-sized committee — applying the spec's optional-field rules.
+//!
+//! The mirror is minimal-preset only: it decodes 32-key committees. Mainnet
+//! committee decode is not yet wired.
 
 use crate::config::Fork;
 use crate::types::consensus::{
@@ -11,15 +14,18 @@ use crate::types::consensus::{
     LightClientUpdate, SyncAggregate, SyncCommittee,
 };
 use crate::types::primitives::Root;
-use ssz_rs::prelude::*;
+use ssz::Decode as _;
+use ssz_derive::Decode;
+use ssz_types::typenum::{U20, U256 as BloomBytes, U32, U4, U48, U5, U6, U96};
+use ssz_types::{BitVector, FixedVector, VariableList};
 
-#[derive(Default, SimpleSerialize)]
+#[derive(Decode)]
 struct RawBeaconBlockHeader {
     slot: u64,
     proposer_index: u64,
-    parent_root: Node,
-    state_root: Node,
-    body_root: Node,
+    parent_root: Root,
+    state_root: Root,
+    body_root: Root,
 }
 
 impl RawBeaconBlockHeader {
@@ -27,35 +33,35 @@ impl RawBeaconBlockHeader {
         BeaconBlockHeader::new(
             self.slot,
             self.proposer_index,
-            node_to_root(&self.parent_root),
-            node_to_root(&self.state_root),
-            node_to_root(&self.body_root),
+            self.parent_root,
+            self.state_root,
+            self.body_root,
         )
     }
 }
 
-#[derive(Default, SimpleSerialize)]
+#[derive(Decode)]
 pub(crate) struct RawLightClientHeader {
     beacon: RawBeaconBlockHeader,
 }
 
-#[derive(Default, SimpleSerialize)]
+#[derive(Decode)]
 pub(crate) struct RawLightClientBootstrap {
     pub(crate) header: RawLightClientHeader,
     pub(crate) current_sync_committee: RawSyncCommittee,
-    pub(crate) current_sync_committee_branch: Vector<Node, 5>,
+    pub(crate) current_sync_committee_branch: FixedVector<Root, U5>,
 }
 
-#[derive(Default, SimpleSerialize)]
+#[derive(Decode)]
 pub(crate) struct RawSyncCommittee {
-    pubkeys: Vector<Vector<u8, 48>, 32>,
-    aggregate_pubkey: Vector<u8, 48>,
+    pubkeys: FixedVector<FixedVector<u8, U48>, U32>,
+    aggregate_pubkey: FixedVector<u8, U48>,
 }
 
 impl RawSyncCommittee {
     pub(crate) fn into_sync_committee(self) -> SyncCommittee {
-        // Minimal fixtures hold exactly 32 pubkeys (guaranteed by the SSZ
-        // `Vector<_, 32>` decode) — the spec-sized minimal committee, no padding.
+        // Minimal fixtures hold exactly 32 pubkeys (SSZ `Vector<_, 32>` decode) —
+        // the spec-sized minimal committee, no padding.
         let pubkeys: Vec<[u8; 48]> = self
             .pubkeys
             .iter()
@@ -74,16 +80,16 @@ impl RawSyncCommittee {
     }
 }
 
-#[derive(Default, SimpleSerialize)]
+#[derive(Decode)]
 struct RawSyncAggregate {
-    sync_committee_bits: Bitvector<32>,
-    sync_committee_signature: Vector<u8, 96>,
+    sync_committee_bits: BitVector<U32>,
+    sync_committee_signature: FixedVector<u8, U96>,
 }
 
 impl RawSyncAggregate {
     fn into_sync_aggregate(self) -> SyncAggregate {
         // Spec-sized bits (32 for minimal fixtures), no padding.
-        let bits: Vec<bool> = self.sync_committee_bits.iter().map(|b| *b).collect();
+        let bits: Vec<bool> = self.sync_committee_bits.iter().collect();
 
         let mut signature = [0u8; 96];
         signature.copy_from_slice(self.sync_committee_signature.as_ref());
@@ -93,93 +99,82 @@ impl RawSyncAggregate {
 }
 
 // Altair/Bellatrix update (beacon-only headers)
-#[derive(Default, SimpleSerialize)]
+#[derive(Decode)]
 pub(crate) struct RawLightClientUpdate {
     attested_header: RawLightClientHeader,
     next_sync_committee: RawSyncCommittee,
-    next_sync_committee_branch: Vector<Node, 5>,
+    next_sync_committee_branch: FixedVector<Root, U5>,
     finalized_header: RawLightClientHeader,
-    finality_branch: Vector<Node, 6>,
+    finality_branch: FixedVector<Root, U6>,
     sync_aggregate: RawSyncAggregate,
     signature_slot: u64,
 }
 
-#[derive(Default, SimpleSerialize)]
+#[derive(Decode)]
 struct RawExecutionPayloadHeader {
-    parent_hash: Node,
-    fee_recipient: Vector<u8, 20>,
-    state_root: Node,
-    receipts_root: Node,
-    logs_bloom: Vector<u8, 256>,
-    prev_randao: Node,
+    parent_hash: Root,
+    fee_recipient: FixedVector<u8, U20>,
+    state_root: Root,
+    receipts_root: Root,
+    logs_bloom: FixedVector<u8, BloomBytes>,
+    prev_randao: Root,
     block_number: u64,
     gas_limit: u64,
     gas_used: u64,
     timestamp: u64,
-    extra_data: List<u8, 32>,
-    base_fee_per_gas: ssz_rs::U256,
-    block_hash: Node,
-    transactions_root: Node,
-    withdrawals_root: Node,
+    extra_data: VariableList<u8, U32>,
+    base_fee_per_gas: ethereum_types::U256,
+    block_hash: Root,
+    transactions_root: Root,
+    withdrawals_root: Root,
 }
 
 impl RawExecutionPayloadHeader {
-    fn into_execution_payload_header(self) -> crate::error::Result<ExecutionPayloadHeaderCapella> {
+    fn into_execution_payload_header(self) -> ExecutionPayloadHeaderCapella {
         let mut fee_recipient = [0u8; 20];
         fee_recipient.copy_from_slice(self.fee_recipient.as_ref());
 
-        // ssz_rs::U256 -> ethereum_types::U256 via LE bytes.
-        let le_bytes = self.base_fee_per_gas.to_bytes_le();
-        let mut u256_bytes = [0u8; 32];
-        let len = le_bytes.len().min(32);
-        u256_bytes[..len].copy_from_slice(&le_bytes[..len]);
-
-        let logs_bloom = ssz_types::FixedVector::new(self.logs_bloom.as_ref().to_vec())
-            .map_err(|e| crate::error::Error::Serialization(format!("logs_bloom: {e:?}")))?;
-        let extra_data = ssz_types::VariableList::new(self.extra_data.to_vec())
-            .map_err(|e| crate::error::Error::Serialization(format!("extra_data: {e:?}")))?;
-
-        Ok(ExecutionPayloadHeaderCapella {
-            parent_hash: node_to_root(&self.parent_hash),
+        ExecutionPayloadHeaderCapella {
+            parent_hash: self.parent_hash,
             fee_recipient: ethereum_types::H160(fee_recipient),
-            state_root: node_to_root(&self.state_root),
-            receipts_root: node_to_root(&self.receipts_root),
-            logs_bloom,
-            prev_randao: node_to_root(&self.prev_randao),
+            state_root: self.state_root,
+            receipts_root: self.receipts_root,
+            logs_bloom: self.logs_bloom,
+            prev_randao: self.prev_randao,
             block_number: self.block_number,
             gas_limit: self.gas_limit,
             gas_used: self.gas_used,
             timestamp: self.timestamp,
-            extra_data,
-            base_fee_per_gas: ethereum_types::U256::from_little_endian(&u256_bytes),
-            block_hash: node_to_root(&self.block_hash),
-            transactions_root: node_to_root(&self.transactions_root),
-            withdrawals_root: node_to_root(&self.withdrawals_root),
-        })
+            extra_data: self.extra_data,
+            base_fee_per_gas: self.base_fee_per_gas,
+            block_hash: self.block_hash,
+            transactions_root: self.transactions_root,
+            withdrawals_root: self.withdrawals_root,
+        }
     }
 }
 
-#[derive(Default, SimpleSerialize)]
+#[derive(Decode)]
 pub(crate) struct RawCapellaLightClientHeader {
     beacon: RawBeaconBlockHeader,
     execution: RawExecutionPayloadHeader,
-    execution_branch: Vector<Node, 4>,
+    execution_branch: FixedVector<Root, U4>,
 }
 
-#[derive(Default, SimpleSerialize)]
+#[derive(Decode)]
 pub(crate) struct RawCapellaLightClientBootstrap {
     pub(crate) header: RawCapellaLightClientHeader,
     pub(crate) current_sync_committee: RawSyncCommittee,
-    pub(crate) current_sync_committee_branch: Vector<Node, 5>,
+    pub(crate) current_sync_committee_branch: FixedVector<Root, U5>,
 }
 
-#[derive(Default, SimpleSerialize)]
+#[derive(Decode)]
 pub(crate) struct RawCapellaLightClientUpdate {
     attested_header: RawCapellaLightClientHeader,
     next_sync_committee: RawSyncCommittee,
-    next_sync_committee_branch: Vector<Node, 5>,
+    next_sync_committee_branch: FixedVector<Root, U5>,
     finalized_header: RawCapellaLightClientHeader,
-    finality_branch: Vector<Node, 6>,
+    finality_branch: FixedVector<Root, U6>,
     sync_aggregate: RawSyncAggregate,
     signature_slot: u64,
 }
@@ -200,32 +195,14 @@ pub(crate) fn raw_beacon_only_header_to_pub(
     }
 }
 
-pub(crate) fn raw_capella_header_to_pub(
-    raw: RawCapellaLightClientHeader,
-) -> crate::error::Result<LightClientHeader> {
+pub(crate) fn raw_capella_header_to_pub(raw: RawCapellaLightClientHeader) -> LightClientHeader {
     let beacon = raw.beacon.into_beacon_block_header();
-    let execution = raw.execution.into_execution_payload_header()?;
+    let execution = raw.execution.into_execution_payload_header();
     let mut execution_branch = [[0u8; 32]; 4];
     for (i, node) in raw.execution_branch.iter().enumerate() {
-        execution_branch[i] = node_to_root(node);
+        execution_branch[i] = *node;
     }
-    Ok(LightClientHeader::capella(
-        beacon,
-        execution,
-        execution_branch,
-    ))
-}
-
-/// Copy a 32-byte SSZ node into a `Root`.
-fn node_to_root(node: &Node) -> Root {
-    let mut root = [0u8; 32];
-    root.copy_from_slice(node.as_ref());
-    root
-}
-
-/// Convert a branch of SSZ nodes into `Root`s.
-pub(crate) fn nodes_to_roots(nodes: &[Node]) -> Vec<Root> {
-    nodes.iter().map(node_to_root).collect()
+    LightClientHeader::capella(beacon, execution, execution_branch)
 }
 
 /// Assemble a `LightClientUpdate` from converted parts, applying the spec's
@@ -272,8 +249,8 @@ pub(crate) fn raw_beacon_only_update_to_pub(
 ) -> LightClientUpdate {
     let sync_committee = raw.next_sync_committee.into_sync_committee();
     let sync_aggregate = raw.sync_aggregate.into_sync_aggregate();
-    let finality_branch = nodes_to_roots(&raw.finality_branch);
-    let next_sync_committee_branch = nodes_to_roots(&raw.next_sync_committee_branch);
+    let finality_branch = raw.finality_branch.to_vec();
+    let next_sync_committee_branch = raw.next_sync_committee_branch.to_vec();
 
     // A default (slot-0) finalized header means the update carries no finality.
     let finalized_header = if raw.finalized_header.beacon.slot != 0 {
@@ -294,23 +271,21 @@ pub(crate) fn raw_beacon_only_update_to_pub(
     )
 }
 
-pub(crate) fn raw_capella_update_to_pub(
-    raw: RawCapellaLightClientUpdate,
-) -> crate::error::Result<LightClientUpdate> {
+pub(crate) fn raw_capella_update_to_pub(raw: RawCapellaLightClientUpdate) -> LightClientUpdate {
     let sync_committee = raw.next_sync_committee.into_sync_committee();
     let sync_aggregate = raw.sync_aggregate.into_sync_aggregate();
-    let finality_branch = nodes_to_roots(&raw.finality_branch);
-    let next_sync_committee_branch = nodes_to_roots(&raw.next_sync_committee_branch);
+    let finality_branch = raw.finality_branch.to_vec();
+    let next_sync_committee_branch = raw.next_sync_committee_branch.to_vec();
 
     // A default (slot-0) finalized header means the update carries no finality.
     let finalized_header = if raw.finalized_header.beacon.slot != 0 {
-        Some(raw_capella_header_to_pub(raw.finalized_header)?)
+        Some(raw_capella_header_to_pub(raw.finalized_header))
     } else {
         None
     };
-    let attested_header = raw_capella_header_to_pub(raw.attested_header)?;
+    let attested_header = raw_capella_header_to_pub(raw.attested_header);
 
-    Ok(assemble_update(
+    assemble_update(
         attested_header,
         finalized_header,
         finality_branch,
@@ -318,7 +293,7 @@ pub(crate) fn raw_capella_update_to_pub(
         next_sync_committee_branch,
         sync_aggregate,
         raw.signature_slot,
-    ))
+    )
 }
 
 // Fork-dispatched SSZ decode: raw bytes -> public type. `bytes` is raw SSZ (not
@@ -327,12 +302,12 @@ pub(crate) fn raw_capella_update_to_pub(
 pub(crate) fn decode_update(bytes: &[u8], fork: Fork) -> crate::error::Result<LightClientUpdate> {
     match fork {
         Fork::Altair | Fork::Bellatrix => {
-            let raw = RawLightClientUpdate::deserialize(bytes).map_err(decode_err)?;
+            let raw = RawLightClientUpdate::from_ssz_bytes(bytes).map_err(decode_err)?;
             Ok(raw_beacon_only_update_to_pub(fork, raw))
         }
         Fork::Capella => {
-            let raw = RawCapellaLightClientUpdate::deserialize(bytes).map_err(decode_err)?;
-            raw_capella_update_to_pub(raw)
+            let raw = RawCapellaLightClientUpdate::from_ssz_bytes(bytes).map_err(decode_err)?;
+            Ok(raw_capella_update_to_pub(raw))
         }
         Fork::Deneb | Fork::Electra => Err(unsupported(fork)),
     }
@@ -345,9 +320,9 @@ pub(crate) fn decode_bootstrap(
 ) -> crate::error::Result<LightClientBootstrap> {
     match fork {
         Fork::Altair | Fork::Bellatrix => {
-            let raw = RawLightClientBootstrap::deserialize(bytes).map_err(decode_err)?;
+            let raw = RawLightClientBootstrap::from_ssz_bytes(bytes).map_err(decode_err)?;
             let sync_committee = raw.current_sync_committee.into_sync_committee();
-            let branch = nodes_to_roots(&raw.current_sync_committee_branch);
+            let branch = raw.current_sync_committee_branch.to_vec();
             let header = raw_beacon_only_header_to_pub(fork, raw.header);
             Ok(LightClientBootstrap::from_header(
                 header,
@@ -357,10 +332,10 @@ pub(crate) fn decode_bootstrap(
             ))
         }
         Fork::Capella => {
-            let raw = RawCapellaLightClientBootstrap::deserialize(bytes).map_err(decode_err)?;
+            let raw = RawCapellaLightClientBootstrap::from_ssz_bytes(bytes).map_err(decode_err)?;
             let sync_committee = raw.current_sync_committee.into_sync_committee();
-            let branch = nodes_to_roots(&raw.current_sync_committee_branch);
-            let header = raw_capella_header_to_pub(raw.header)?;
+            let branch = raw.current_sync_committee_branch.to_vec();
+            let header = raw_capella_header_to_pub(raw.header);
             Ok(LightClientBootstrap::from_header(
                 header,
                 sync_committee,
@@ -372,7 +347,7 @@ pub(crate) fn decode_bootstrap(
     }
 }
 
-fn decode_err(e: ssz_rs::DeserializeError) -> crate::error::Error {
+fn decode_err(e: ssz::DecodeError) -> crate::error::Error {
     crate::error::Error::Serialization(format!("SSZ decode: {e:?}"))
 }
 


### PR DESCRIPTION
Final step of the SSZ-native arc (#69): drop `ssz_rs`, the crate's second SSZ library.

## Summary
After PRs #71-73 made the public types SSZ-native, `ssz_rs`'s only job was decoding a handful of `Raw*` wire structs. This PR ports them to `ethereum_ssz` + `ssz_types`, drops `ssz_rs`, and collapses the now-redundant header mirrors.

**Commit 1 — port off `ssz_rs`:**
- `Raw*` structs derive `ethereum_ssz`'s `Decode` with `ssz_types` field types (`Node → [u8;32]`, `Vector → FixedVector`, `Bitvector → BitVector`, `List → VariableList`, `ssz_rs::U256 → ethereum_types::U256`).
- Remove `ssz_rs` (normal + dev dep). The dep tree is now one SSZ ecosystem: `ethereum_ssz` + `ssz_types` + `tree_hash`.
- README "SSZ libraries" note rewritten (now "SSZ": a single implementation).

**Commit 2 — collapse redundant `Raw*` header types:**
- The public headers self-decode (PR #73), so wire structs hold them directly: `BeaconBlockHeader` for beacon-only (the 1-field wrapper is serialization-transparent), `CapellaLightClientHeader` for Capella.
- Deletes `RawBeaconBlockHeader`, `RawLightClientHeader`, `RawExecutionPayloadHeader`, `RawCapellaLightClientHeader` + their converters. `ssz.rs`: ~384 → 241 lines; the 6 remaining `Raw*` types are only the committee/aggregate/update/bootstrap that need real conversion.

## The proof
Spec tests green: `ethereum_ssz` decodes the official Altair/Bellatrix/Capella fixtures byte-identically to `ssz_rs` (full verification passes). `clippy -D warnings` clean.

## This completes the #69 arc
- Every type root is derived — zero hand-written merkleization (only the Merkle branch-walk primitive remains, which is correct/inherent).
- `ruint` gone (#71), #21 resolved (#72), `ssz_rs` gone (this).
- One SSZ implementation.

Closes #69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)