### PR TITLE
BLS module slim-down + KeyValidate conformance fix

### DIFF
--- a/src/consensus/bls.rs
+++ b/src/consensus/bls.rs
@@ -14,14 +14,15 @@ const DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
 
 /// Same-message aggregate verification — the sole BLS entry point.
 ///
-/// All sync committee signature checks go through this. It parses the
-/// participating pubkeys and the aggregate signature, then defers to blst's
-/// native `fast_aggregate_verify`, which is the complete primitive for the
-/// one-message/many-signers case. Any parse error or non-success status is a
-/// verification failure (`false`).
+/// All sync committee signature checks go through this. It parses and
+/// `KeyValidate`s the participating pubkeys and parses the aggregate signature,
+/// then defers to blst's native `fast_aggregate_verify`, which is the complete
+/// primitive for the one-message/many-signers case. Any parse failure or
+/// non-success status is a verification failure (`false`).
 ///
-/// Infinity handling follows the consensus spec: all-zero pubkeys are skipped,
-/// and an empty participating set verifies only against an infinity signature.
+/// Per the consensus-spec `FastAggregateVerify`, an empty pubkey set is invalid,
+/// and each pubkey is `KeyValidate`d — a set containing the infinity pubkey (or
+/// any non-subgroup key) is rejected outright, not filtered.
 pub(crate) fn fast_aggregate_verify(
     pubkeys: &[[u8; 48]],
     message: &[u8],
@@ -31,21 +32,18 @@ pub(crate) fn fast_aggregate_verify(
         return false;
     }
 
-    // Parse pubkeys, skipping infinity (all-zero) entries.
+    // Parse and KeyValidate every pubkey. KeyValidate rejects the infinity point
+    // and non-subgroup keys, so any such key fails the whole verification.
     let mut pks: Vec<PublicKey> = Vec::with_capacity(pubkeys.len());
     for pk_bytes in pubkeys {
-        if pk_bytes.iter().all(|&b| b == 0) {
-            continue;
-        }
-        match PublicKey::from_bytes(pk_bytes) {
-            Ok(pk) => pks.push(pk),
+        let pk = match PublicKey::from_bytes(pk_bytes) {
+            Ok(pk) => pk,
             Err(_) => return false,
+        };
+        if pk.validate().is_err() {
+            return false;
         }
-    }
-
-    // Empty participating set: valid only if the signature is also infinity.
-    if pks.is_empty() {
-        return signature.iter().all(|&b| b == 0);
+        pks.push(pk);
     }
 
     let sig = match Signature::from_bytes(signature) {
@@ -53,7 +51,6 @@ pub(crate) fn fast_aggregate_verify(
         Err(_) => return false,
     };
 
-    // blst's `fast_aggregate_verify` performs the group checks internally.
     let pk_refs: Vec<&PublicKey> = pks.iter().collect();
     matches!(
         sig.fast_aggregate_verify(true, message, DST, &pk_refs),

--- a/src/consensus/bls.rs
+++ b/src/consensus/bls.rs
@@ -1,349 +1,62 @@
 //! BLS Signature Verification Module
 //!
-//! Provides BLS signature verification functions for Ethereum consensus layer.
-//! Uses the blst library for efficient BLS12-381 operations.
-//!
-//! This module is designed to be compliant with Ethereum consensus spec tests.
+//! Same-message aggregate signature verification for the Ethereum consensus
+//! layer. Every actual BLS12-381 operation is delegated to `blst`; this module
+//! is the thin adapter that applies Ethereum's conventions (the DST, infinity
+//! handling) and marshals our byte types into blst's API.
 use blst::{
-    min_pk::{AggregatePublicKey, PublicKey, Signature},
+    min_pk::{PublicKey, Signature},
     BLST_ERROR,
 };
 
 // Ethereum consensus DST (domain separation tag)
 const DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
 
-/// Manual aggregate-then-verify fallback.
+/// Same-message aggregate verification — the sole BLS entry point.
 ///
-/// Parses and validates each public key, aggregates them into a single
-/// `AggregatePublicKey`, then verifies the signature with `sig.verify()`.
+/// All sync committee signature checks go through this. It parses the
+/// participating pubkeys and the aggregate signature, then defers to blst's
+/// native `fast_aggregate_verify`, which is the complete primitive for the
+/// one-message/many-signers case. Any parse error or non-success status is a
+/// verification failure (`false`).
 ///
-/// This is the slow path — used only when `fast_aggregate_verify_native`
-/// returns `None` (e.g. a parse error that blst surfaces as a non-success,
-/// non-verify-fail status).
-fn aggregate_then_verify_fallback(
-    pubkeys: &[[u8; 48]],
-    message: &[u8],
-    signature: &[u8; 96],
-) -> bool {
-    // Handle empty pubkeys
-    if pubkeys.is_empty() {
-        return false;
-    }
-
-    // Parse and validate public keys
-    let mut pks = Vec::new();
-    for pubkey_bytes in pubkeys {
-        // Skip infinity/identity pubkeys
-        if pubkey_bytes.iter().all(|&b| b == 0) {
-            continue;
-        }
-
-        match PublicKey::from_bytes(pubkey_bytes) {
-            Ok(pk) => {
-                if pk.validate().is_ok() {
-                    pks.push(pk);
-                } else {
-                    return false;
-                }
-            }
-            Err(_) => return false,
-        }
-    }
-
-    // If all pubkeys were infinity, check if signature is also infinity
-    if pks.is_empty() {
-        return signature.iter().all(|&b| b == 0);
-    }
-
-    // Parse signature
-    let sig = match Signature::from_bytes(signature) {
-        Ok(sig) => sig,
-        Err(_) => return false,
-    };
-
-    // Validate signature
-    if sig.validate(false).is_err() {
-        return false;
-    }
-
-    // Aggregate public keys
-    let agg_pk = match aggregate_pubkeys(&pks) {
-        Some(pk) => pk,
-        None => return false,
-    };
-
-    // Verify aggregate signature
-    matches!(
-        sig.verify(false, message, DST, &[], &agg_pk, false),
-        BLST_ERROR::BLST_SUCCESS
-    )
-}
-
-/// Primary entry point for same-message aggregate signature verification.
-///
-/// All sync committee BLS checks go through this function.  It first
-/// attempts blst's native `fast_aggregate_verify` (optimal single-message
-/// path).  If that returns an unexpected error, it falls back to the
-/// manual `aggregate_then_verify_fallback`.
+/// Infinity handling follows the consensus spec: all-zero pubkeys are skipped,
+/// and an empty participating set verifies only against an infinity signature.
 pub(crate) fn fast_aggregate_verify(
     pubkeys: &[[u8; 48]],
     message: &[u8],
     signature: &[u8; 96],
 ) -> bool {
-    // Try using blst's native fast_aggregate_verify first
-    if let Some(result) = fast_aggregate_verify_native(pubkeys, message, signature) {
-        return result;
-    }
-
-    // Fallback to manual aggregate-then-verify approach
-    aggregate_then_verify_fallback(pubkeys, message, signature)
-}
-
-/// Native blst fast path — calls `sig.fast_aggregate_verify()` directly.
-fn fast_aggregate_verify_native(
-    pubkeys: &[[u8; 48]],
-    message: &[u8],
-    signature: &[u8; 96],
-) -> Option<bool> {
     if pubkeys.is_empty() {
-        return Some(false);
+        return false;
     }
 
-    // Parse all public keys
+    // Parse pubkeys, skipping infinity (all-zero) entries.
     let mut pks: Vec<PublicKey> = Vec::with_capacity(pubkeys.len());
     for pk_bytes in pubkeys {
         if pk_bytes.iter().all(|&b| b == 0) {
-            continue; // Skip infinity
+            continue;
         }
         match PublicKey::from_bytes(pk_bytes) {
             Ok(pk) => pks.push(pk),
-            Err(_) => return None,
+            Err(_) => return false,
         }
     }
 
+    // Empty participating set: valid only if the signature is also infinity.
     if pks.is_empty() {
-        return Some(signature.iter().all(|&b| b == 0));
-    }
-
-    // Parse signature
-    let sig = match Signature::from_bytes(signature) {
-        Ok(s) => s,
-        Err(_) => return None,
-    };
-
-    // Create references for fast_aggregate_verify
-    let pk_refs: Vec<&PublicKey> = pks.iter().collect();
-
-    // Use blst's native fast_aggregate_verify
-    //
-    // Note: we intentionally don't call `pk.validate()` here.
-    // blst's `fast_aggregate_verify` performs the necessary checks internally.
-    // If it returns an unexpected error, we fall back to the slower path which
-    // validates pubkeys explicitly.
-    match sig.fast_aggregate_verify(true, message, DST, &pk_refs) {
-        BLST_ERROR::BLST_SUCCESS => Some(true),
-        BLST_ERROR::BLST_VERIFY_FAIL => Some(false),
-        _ => None, // Some other error, fall back
-    }
-}
-
-/// Aggregate multiple BLS public keys
-fn aggregate_pubkeys(pubkeys: &[PublicKey]) -> Option<PublicKey> {
-    if pubkeys.is_empty() {
-        return None;
-    }
-
-    // Start with first public key
-    let mut aggregate = AggregatePublicKey::from_public_key(&pubkeys[0]);
-
-    // Add remaining keys
-    for pk in &pubkeys[1..] {
-        if aggregate.add_public_key(pk, false).is_err() {
-            return None;
-        }
-    }
-
-    Some(aggregate.to_public_key())
-}
-
-/// Verify a single BLS signature
-///
-/// # Arguments
-/// * `pubkey` - 48-byte BLS public key
-/// * `message` - Message bytes to verify
-/// * `signature` - 96-byte BLS signature
-///
-/// # Returns
-/// * `true` if signature is valid, `false` otherwise
-#[cfg(test)]
-pub fn verify_bls_signature(pubkey: &[u8; 48], message: &[u8], signature: &[u8; 96]) -> bool {
-    // Handle infinity/identity pubkey (all zeros)
-    if pubkey.iter().all(|&b| b == 0) {
-        // Infinity pubkey with infinity signature is considered valid
-        // per Ethereum consensus specs
         return signature.iter().all(|&b| b == 0);
     }
 
-    // Parse public key
-    let pk = match PublicKey::from_bytes(pubkey) {
-        Ok(pk) => pk,
-        Err(_) => return false,
-    };
-
-    // Validate public key
-    if pk.validate().is_err() {
-        return false;
-    }
-
-    // Parse signature
     let sig = match Signature::from_bytes(signature) {
-        Ok(sig) => sig,
+        Ok(s) => s,
         Err(_) => return false,
     };
 
-    // Validate signature
-    if sig.validate(false).is_err() {
-        return false;
-    }
-
-    // Verify signature
+    // blst's `fast_aggregate_verify` performs the group checks internally.
+    let pk_refs: Vec<&PublicKey> = pks.iter().collect();
     matches!(
-        sig.verify(false, message, DST, &[], &pk, false),
+        sig.fast_aggregate_verify(true, message, DST, &pk_refs),
         BLST_ERROR::BLST_SUCCESS
     )
-}
-
-/// Aggregate multiple BLS signatures
-#[cfg(test)]
-pub fn aggregate_signatures(signatures: &[[u8; 96]]) -> Result<[u8; 96], String> {
-    use blst::min_pk::AggregateSignature;
-
-    if signatures.is_empty() {
-        return Err("No signatures to aggregate".to_string());
-    }
-
-    // Parse all signatures first
-    let mut sigs = Vec::new();
-    for sig_bytes in signatures {
-        let sig =
-            Signature::from_bytes(sig_bytes).map_err(|e| format!("Invalid signature: {:?}", e))?;
-        sigs.push(sig);
-    }
-
-    // Create aggregate from first signature
-    let mut agg_sig = AggregateSignature::from_signature(&sigs[0]);
-
-    // Add remaining signatures
-    for sig in &sigs[1..] {
-        agg_sig
-            .add_signature(sig, false)
-            .map_err(|e| format!("Failed to add signature: {:?}", e))?;
-    }
-
-    let result = agg_sig.to_signature();
-    Ok(result.to_bytes())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use blst::min_pk::SecretKey;
-
-    #[test]
-    fn test_single_signature_verification() {
-        // Generate a test keypair
-        let sk_bytes = [42u8; 32];
-        let sk = SecretKey::from_bytes(&sk_bytes).unwrap();
-        let pk = sk.sk_to_pk();
-
-        // Sign a message
-        let message = b"test message";
-        let sig = sk.sign(message, DST, &[]);
-
-        // Verify signature
-        let pubkey = pk.to_bytes();
-        let signature = sig.to_bytes();
-
-        assert!(verify_bls_signature(&pubkey, message, &signature));
-
-        // Verify with wrong message should fail
-        assert!(!verify_bls_signature(&pubkey, b"wrong message", &signature));
-
-        // Verify with wrong pubkey should fail
-        let wrong_sk = SecretKey::from_bytes(&[43u8; 32]).unwrap();
-        let wrong_pk = wrong_sk.sk_to_pk().to_bytes();
-        assert!(!verify_bls_signature(&wrong_pk, message, &signature));
-    }
-
-    #[test]
-    fn test_aggregate_signature_verification() {
-        // Generate multiple keypairs
-        let mut pubkeys = Vec::new();
-        let mut sigs = Vec::new();
-
-        let message = b"aggregate test message";
-
-        // Note: Secret key bytes cannot be all zeros (invalid scalar)
-        // Use non-zero values starting from 1
-        for i in 1..=3 {
-            let sk_bytes = [i as u8; 32];
-            let sk = SecretKey::from_bytes(&sk_bytes).unwrap();
-            let pk = sk.sk_to_pk();
-            let sig = sk.sign(message, DST, &[]);
-
-            pubkeys.push(pk.to_bytes());
-            sigs.push(sig.to_bytes());
-        }
-
-        // Aggregate signatures
-        let agg_sig = aggregate_signatures(&sigs).unwrap();
-
-        // Verify aggregate
-        assert!(aggregate_then_verify_fallback(&pubkeys, message, &agg_sig));
-
-        // Verify with wrong message should fail
-        assert!(!aggregate_then_verify_fallback(
-            &pubkeys, b"wrong", &agg_sig
-        ));
-    }
-
-    #[test]
-    fn test_infinity_point_handling() {
-        // Test infinity pubkey and signature (all zeros)
-        let infinity_pubkey = [0u8; 48];
-        let infinity_signature = [0u8; 96];
-        let message = b"any message";
-
-        // Infinity pubkey with infinity signature should be valid
-        assert!(verify_bls_signature(
-            &infinity_pubkey,
-            message,
-            &infinity_signature
-        ));
-
-        // Infinity pubkey with non-infinity signature should be invalid
-        let non_infinity_sig = [1u8; 96];
-        assert!(!verify_bls_signature(
-            &infinity_pubkey,
-            message,
-            &non_infinity_sig
-        ));
-    }
-
-    #[test]
-    fn test_invalid_inputs() {
-        // Test with invalid pubkey bytes (not on curve)
-        let invalid_pubkey = [0xffu8; 48];
-        let signature = [0u8; 96];
-        let message = b"test";
-
-        assert!(!verify_bls_signature(&invalid_pubkey, message, &signature));
-
-        // Test with invalid signature bytes
-        let sk = SecretKey::from_bytes(&[1u8; 32]).unwrap();
-        let pubkey = sk.sk_to_pk().to_bytes();
-        let invalid_signature = [0xffu8; 96];
-
-        assert!(!verify_bls_signature(&pubkey, message, &invalid_signature));
-    }
 }

--- a/src/consensus/bls_spec_tests.rs
+++ b/src/consensus/bls_spec_tests.rs
@@ -47,12 +47,6 @@ fn fixed<const N: usize>(bytes: &[u8]) -> [u8; N] {
     bytes.try_into().expect("unexpected fixture field length")
 }
 
-/// Known non-conformance, fixed in the follow-up commit: `fast_aggregate_verify`
-/// does not yet run `KeyValidate`, so it accepts a pubkey set containing the
-/// infinity point. Tolerated here to keep the mechanical slim-down green; the
-/// follow-up adds the fix and removes this allowance. See issue #76.
-const KNOWN_NONCONFORMANCE: &[&str] = &["fast_aggregate_verify_infinity_pubkey"];
-
 /// Run every official `fast_aggregate_verify` vector through our production
 /// path. Strict: any mismatch fails the suite (all mismatches are reported).
 #[test]
@@ -97,7 +91,7 @@ fn fast_aggregate_verify_spec_vectors() {
         let signature: [u8; 96] = fixed(&parse_hex(&case.input.signature));
 
         let actual = fast_aggregate_verify(&pubkeys, &message, &signature);
-        if actual != case.output && !KNOWN_NONCONFORMANCE.contains(&name.as_str()) {
+        if actual != case.output {
             failures.push(format!("{name}: expected {}, got {actual}", case.output));
         }
         checked += 1;

--- a/src/consensus/bls_spec_tests.rs
+++ b/src/consensus/bls_spec_tests.rs
@@ -1,516 +1,113 @@
 #![cfg(test)]
-//! BLS Integration Test Suite
+//! BLS spec-vector tests.
 //!
-//! Validates our BLS wrapper layer (src/consensus/bls.rs) against official
-//! Ethereum consensus spec tests. These tests do NOT test the blst library
-//! itself (which is already extensively tested) - they validate that OUR code:
+//! Validates our BLS wrapper (`src/consensus/bls.rs`) against the official
+//! Ethereum `fast_aggregate_verify` consensus vectors. These do NOT test blst
+//! itself (already extensively tested) — they pin down that OUR adapter uses
+//! the correct DST, handles infinity / empty sets per spec, and marshals
+//! parameters correctly, including the negative cases (tampered signatures,
+//! wrong pubkey sets) that the light-client fixture replays never reach.
 //!
-//! - Uses the correct Ethereum DST constant
-//! - Properly handles infinity points per Ethereum spec
-//! - Correctly passes parameters to blst functions
-//! - Handles edge cases (invalid keys, tampered signatures, etc.)
-//!
-//! Test vectors sourced from: https://github.com/ethereum/consensus-spec-tests
-//!
-//! Test format:
-//! - YAML files with input: {pubkey(s), message, signature}
-//! - Expected output: true/false
-//!
-//! Covers:
-//! - Single signature verification (verify/)
-//! - Fast aggregate verification (fast_aggregate_verify/)
-//!
-//! Setup:
-//! 1. Clone consensus-spec-tests to tests/fixtures/consensus-spec-tests/
-//! 2. Or set CONSENSUS_SPEC_TESTS_PATH environment variable to test data location
-//!
-//! Status: 40/40 tests passing
+//! Vectors: <https://github.com/ethereum/consensus-spec-tests>
+//! Setup: clone consensus-spec-tests into `tests/fixtures/consensus-spec-tests/`
+//! or set `CONSENSUS_SPEC_TESTS_PATH`.
 
+use crate::consensus::bls::fast_aggregate_verify;
 use serde::Deserialize;
-use std::env;
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
+use std::{env, fs};
 use walkdir::WalkDir;
 
-// Import our BLS verification functions (crate-internal access)
-use crate::consensus::bls::{fast_aggregate_verify, verify_bls_signature};
-
-/// Test case structure for single signature verification
-#[derive(Debug, Deserialize)]
-struct VerifyTestCase {
-    input: VerifyInput,
-    output: bool,
-}
-
-#[derive(Debug, Deserialize)]
-struct VerifyInput {
-    pubkey: String,
-    message: String,
-    signature: String,
-}
-
-/// Test case structure for fast aggregate verification
-#[derive(Debug, Deserialize)]
-struct FastAggregateVerifyTestCase {
+#[derive(Deserialize)]
+struct FastAggregateVerifyCase {
     input: FastAggregateVerifyInput,
     output: bool,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 struct FastAggregateVerifyInput {
     pubkeys: Vec<String>,
     message: String,
     signature: String,
 }
 
-/// Test statistics tracker
-#[derive(Debug, Default)]
-struct TestStats {
-    total: usize,
-    passed: usize,
-    failed: usize,
-    skipped: usize,
-}
-
-impl TestStats {
-    fn add_result(&mut self, passed: bool) {
-        self.total += 1;
-        if passed {
-            self.passed += 1;
-        } else {
-            self.failed += 1;
-        }
-    }
-
-    fn add_skipped(&mut self) {
-        self.total += 1;
-        self.skipped += 1;
-    }
-
-    fn print_summary(&self, test_type: &str) {
-        println!("\n📊 {} Test Summary:", test_type);
-        println!("   Total:   {}", self.total);
-        println!(
-            "   ✅ Passed: {} ({:.1}%)",
-            self.passed,
-            (self.passed as f64 / self.total as f64) * 100.0
-        );
-        println!(
-            "   ❌ Failed: {} ({:.1}%)",
-            self.failed,
-            (self.failed as f64 / self.total as f64) * 100.0
-        );
-        if self.skipped > 0 {
-            println!("   ⏭️  Skipped: {}", self.skipped);
-        }
-    }
-}
-
-/// Get the path to BLS test data, with environment variable fallback
 fn bls_test_path() -> PathBuf {
     env::var("CONSENSUS_SPEC_TESTS_PATH")
         .map(PathBuf::from)
         .unwrap_or_else(|_| {
-            // Default to relative path in project fixtures
             PathBuf::from("tests/fixtures/consensus-spec-tests/tests/general/phase0/bls")
         })
 }
 
-/// Parse hex string to bytes, handling 0x prefix
-fn parse_hex(hex_str: &str) -> Result<Vec<u8>, hex::FromHexError> {
-    let hex_str = hex_str.strip_prefix("0x").unwrap_or(hex_str);
-    hex::decode(hex_str)
+fn parse_hex(s: &str) -> Vec<u8> {
+    hex::decode(s.strip_prefix("0x").unwrap_or(s)).expect("invalid hex in fixture")
 }
 
-/// Run single signature verification tests
-fn run_verify_tests(base_path: &Path) -> TestStats {
-    println!("\n🔐 Running BLS Signature Verification Tests");
-    println!("==========================================");
+fn fixed<const N: usize>(bytes: &[u8]) -> [u8; N] {
+    bytes.try_into().expect("unexpected fixture field length")
+}
 
-    let mut stats = TestStats::default();
-    let test_dir = base_path.join("verify/bls");
+/// Known non-conformance, fixed in the follow-up commit: `fast_aggregate_verify`
+/// does not yet run `KeyValidate`, so it accepts a pubkey set containing the
+/// infinity point. Tolerated here to keep the mechanical slim-down green; the
+/// follow-up adds the fix and removes this allowance. See issue #76.
+const KNOWN_NONCONFORMANCE: &[&str] = &["fast_aggregate_verify_infinity_pubkey"];
 
-    if !test_dir.exists() {
-        println!("⚠️  Test directory not found: {:?}", test_dir);
-        return stats;
-    }
+/// Run every official `fast_aggregate_verify` vector through our production
+/// path. Strict: any mismatch fails the suite (all mismatches are reported).
+#[test]
+fn fast_aggregate_verify_spec_vectors() {
+    let dir = bls_test_path().join("fast_aggregate_verify/bls");
+    assert!(
+        dir.exists(),
+        "BLS fixtures not found at {dir:?}. Clone consensus-spec-tests into \
+         tests/fixtures/ or set CONSENSUS_SPEC_TESTS_PATH."
+    );
 
-    // Iterate through all test cases
-    for entry in WalkDir::new(&test_dir)
+    let mut checked = 0usize;
+    let mut failures = Vec::new();
+
+    for entry in WalkDir::new(&dir)
         .max_depth(2)
         .into_iter()
         .filter_map(|e| e.ok())
     {
-        let path = entry.path();
-        if path.file_name() == Some(std::ffi::OsStr::new("data.yaml")) {
-            let test_name = path
-                .parent()
-                .and_then(|p| p.file_name())
-                .and_then(|n| n.to_str())
-                .unwrap_or("unknown");
-
-            // Load and parse test case
-            match fs::read_to_string(path) {
-                Ok(contents) => match serde_yaml::from_str::<VerifyTestCase>(&contents) {
-                    Ok(test_case) => {
-                        let result = run_single_verify_test(&test_case, test_name);
-                        stats.add_result(result);
-                    }
-                    Err(e) => {
-                        println!("   ⚠️  Failed to parse {}: {}", test_name, e);
-                        stats.add_skipped();
-                    }
-                },
-                Err(e) => {
-                    println!("   ⚠️  Failed to read {}: {}", test_name, e);
-                    stats.add_skipped();
-                }
-            }
+        if entry.file_name().to_str() != Some("data.yaml") {
+            continue;
         }
+        let name = entry
+            .path()
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|n| n.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let contents = fs::read_to_string(entry.path()).expect("read fixture");
+        let case: FastAggregateVerifyCase =
+            serde_yaml::from_str(&contents).unwrap_or_else(|e| panic!("parse {name}: {e}"));
+
+        let pubkeys: Vec<[u8; 48]> = case
+            .input
+            .pubkeys
+            .iter()
+            .map(|p| fixed(&parse_hex(p)))
+            .collect();
+        let message = parse_hex(&case.input.message);
+        let signature: [u8; 96] = fixed(&parse_hex(&case.input.signature));
+
+        let actual = fast_aggregate_verify(&pubkeys, &message, &signature);
+        if actual != case.output && !KNOWN_NONCONFORMANCE.contains(&name.as_str()) {
+            failures.push(format!("{name}: expected {}, got {actual}", case.output));
+        }
+        checked += 1;
     }
 
-    stats.print_summary("Verify");
-    stats
-}
-
-/// Run a single verification test
-fn run_single_verify_test(test_case: &VerifyTestCase, test_name: &str) -> bool {
-    // Parse hex inputs
-    let pubkey_bytes = match parse_hex(&test_case.input.pubkey) {
-        Ok(bytes) if bytes.len() == 48 => bytes,
-        Ok(bytes) => {
-            println!(
-                "   ❌ {} - Invalid pubkey length: {}",
-                test_name,
-                bytes.len()
-            );
-            return false;
-        }
-        Err(e) => {
-            println!("   ❌ {} - Failed to parse pubkey: {}", test_name, e);
-            return false;
-        }
-    };
-
-    let message_bytes = match parse_hex(&test_case.input.message) {
-        Ok(bytes) => bytes,
-        Err(e) => {
-            println!("   ❌ {} - Failed to parse message: {}", test_name, e);
-            return false;
-        }
-    };
-
-    let signature_bytes = match parse_hex(&test_case.input.signature) {
-        Ok(bytes) if bytes.len() == 96 => bytes,
-        Ok(bytes) => {
-            println!(
-                "   ❌ {} - Invalid signature length: {}",
-                test_name,
-                bytes.len()
-            );
-            return false;
-        }
-        Err(e) => {
-            println!("   ❌ {} - Failed to parse signature: {}", test_name, e);
-            return false;
-        }
-    };
-
-    // Convert to fixed-size arrays
-    let mut pubkey = [0u8; 48];
-    pubkey.copy_from_slice(&pubkey_bytes);
-
-    let mut signature = [0u8; 96];
-    signature.copy_from_slice(&signature_bytes);
-
-    // Run verification
-    let actual = verify_bls_signature(&pubkey, &message_bytes, &signature);
-    let expected = test_case.output;
-
-    if actual == expected {
-        println!("   ✅ {} - PASS", test_name);
-        true
-    } else {
-        println!(
-            "   ❌ {} - FAIL: expected {}, got {}",
-            test_name, expected, actual
-        );
-
-        // Print details for debugging
-        if test_name.contains("tampered") || test_name.contains("invalid") {
-            println!("      (This is expected - tampered/invalid signatures should fail)");
-        } else if test_name.contains("infinity") {
-            println!("      (Special case: infinity point handling)");
-        }
-
-        false
-    }
-}
-
-/// Run fast aggregate verification tests
-fn run_fast_aggregate_verify_tests(base_path: &Path) -> TestStats {
-    println!("\n🔐 Running BLS Fast Aggregate Verification Tests");
-    println!("===============================================");
-
-    let mut stats = TestStats::default();
-    let test_dir = base_path.join("fast_aggregate_verify/bls");
-
-    if !test_dir.exists() {
-        println!("⚠️  Test directory not found: {:?}", test_dir);
-        return stats;
-    }
-
-    // Iterate through all test cases
-    for entry in WalkDir::new(&test_dir)
-        .max_depth(2)
-        .into_iter()
-        .filter_map(|e| e.ok())
-    {
-        let path = entry.path();
-        if path.file_name() == Some(std::ffi::OsStr::new("data.yaml")) {
-            let test_name = path
-                .parent()
-                .and_then(|p| p.file_name())
-                .and_then(|n| n.to_str())
-                .unwrap_or("unknown");
-
-            // Load and parse test case
-            match fs::read_to_string(path) {
-                Ok(contents) => {
-                    match serde_yaml::from_str::<FastAggregateVerifyTestCase>(&contents) {
-                        Ok(test_case) => {
-                            let result = run_single_fast_aggregate_test(&test_case, test_name);
-                            stats.add_result(result);
-                        }
-                        Err(e) => {
-                            println!("   ⚠️  Failed to parse {}: {}", test_name, e);
-                            stats.add_skipped();
-                        }
-                    }
-                }
-                Err(e) => {
-                    println!("   ⚠️  Failed to read {}: {}", test_name, e);
-                    stats.add_skipped();
-                }
-            }
-        }
-    }
-
-    stats.print_summary("Fast Aggregate Verify");
-    stats
-}
-
-/// Run a single fast aggregate verification test
-fn run_single_fast_aggregate_test(
-    test_case: &FastAggregateVerifyTestCase,
-    test_name: &str,
-) -> bool {
-    // Parse pubkeys
-    let mut pubkeys = Vec::new();
-    for pubkey_hex in &test_case.input.pubkeys {
-        match parse_hex(pubkey_hex) {
-            Ok(bytes) if bytes.len() == 48 => {
-                let mut pubkey = [0u8; 48];
-                pubkey.copy_from_slice(&bytes);
-                pubkeys.push(pubkey);
-            }
-            Ok(bytes) => {
-                println!(
-                    "   ❌ {} - Invalid pubkey length: {}",
-                    test_name,
-                    bytes.len()
-                );
-                return false;
-            }
-            Err(e) => {
-                println!("   ❌ {} - Failed to parse pubkey: {}", test_name, e);
-                return false;
-            }
-        }
-    }
-
-    // Parse message
-    let message_bytes = match parse_hex(&test_case.input.message) {
-        Ok(bytes) => bytes,
-        Err(e) => {
-            println!("   ❌ {} - Failed to parse message: {}", test_name, e);
-            return false;
-        }
-    };
-
-    // Parse signature
-    let signature_bytes = match parse_hex(&test_case.input.signature) {
-        Ok(bytes) if bytes.len() == 96 => bytes,
-        Ok(bytes) => {
-            println!(
-                "   ❌ {} - Invalid signature length: {}",
-                test_name,
-                bytes.len()
-            );
-            return false;
-        }
-        Err(e) => {
-            println!("   ❌ {} - Failed to parse signature: {}", test_name, e);
-            return false;
-        }
-    };
-
-    let mut signature = [0u8; 96];
-    signature.copy_from_slice(&signature_bytes);
-
-    // Run verification
-    let actual = fast_aggregate_verify(&pubkeys, &message_bytes, &signature);
-    let expected = test_case.output;
-
-    if actual == expected {
-        println!(
-            "   ✅ {} - PASS ({})",
-            test_name,
-            if test_name.len() > 50 {
-                &test_name[..50]
-            } else {
-                test_name
-            }
-        );
-        true
-    } else {
-        println!(
-            "   ❌ {} - FAIL: expected {}, got {}",
-            test_name, expected, actual
-        );
-
-        // Print details for debugging
-        println!("      Pubkeys count: {}", pubkeys.len());
-        if test_name.contains("extra_pubkey") {
-            println!("      (Extra pubkey test - should handle mismatched pubkey counts)");
-        } else if test_name.contains("infinity") {
-            println!("      (Infinity point handling test)");
-        } else if test_name.contains("tampered") {
-            println!("      (Tampered signature test - should fail)");
-        }
-
-        false
-    }
-}
-
-/// Main test runner for BLS spec tests
-#[test]
-fn test_bls_spec_compliance() {
-    println!("\n");
-    println!("╔═══════════════════════════════════════════════════════╗");
-    println!("║     BLS SPECIFICATION COMPLIANCE TEST RUNNER         ║");
-    println!("╚═══════════════════════════════════════════════════════╝");
-
-    let base_path = bls_test_path();
-
-    if !base_path.exists() {
-        println!("❌ Test directory not found: {:?}", base_path);
-        println!("   Setup instructions:");
-        println!("   1. Clone consensus-spec-tests to tests/fixtures/consensus-spec-tests/");
-        println!("   2. Or set CONSENSUS_SPEC_TESTS_PATH environment variable");
-        println!("   ");
-        println!("   Example setup:");
-        println!("   cd tests/fixtures && git clone https://github.com/ethereum/consensus-spec-tests.git");
-        panic!("BLS test directory not found. See setup instructions above.");
-    }
-
-    println!("\n📁 Test directory: {:?}", base_path);
-    println!(
-        "   Source: {}",
-        if env::var("CONSENSUS_SPEC_TESTS_PATH").is_ok() {
-            "Environment variable CONSENSUS_SPEC_TESTS_PATH"
-        } else {
-            "Default fixtures directory"
-        }
+    assert!(checked > 0, "no BLS fixtures were exercised");
+    assert!(
+        failures.is_empty(),
+        "{} of {checked} fast_aggregate_verify vectors failed:\n{}",
+        failures.len(),
+        failures.join("\n")
     );
-
-    // Run verify tests
-    let verify_stats = run_verify_tests(&base_path);
-
-    // Run fast aggregate verify tests
-    let aggregate_stats = run_fast_aggregate_verify_tests(&base_path);
-
-    // Overall summary
-    println!("\n");
-    println!("╔═══════════════════════════════════════════════════════╗");
-    println!("║                  OVERALL SUMMARY                      ║");
-    println!("╚═══════════════════════════════════════════════════════╝");
-
-    let total_tests = verify_stats.total + aggregate_stats.total;
-    let total_passed = verify_stats.passed + aggregate_stats.passed;
-    let total_failed = verify_stats.failed + aggregate_stats.failed;
-    let total_skipped = verify_stats.skipped + aggregate_stats.skipped;
-
-    println!("📊 Total Tests Run: {}", total_tests);
-    println!(
-        "   ✅ Passed: {} ({:.1}%)",
-        total_passed,
-        (total_passed as f64 / total_tests as f64) * 100.0
-    );
-    println!(
-        "   ❌ Failed: {} ({:.1}%)",
-        total_failed,
-        (total_failed as f64 / total_tests as f64) * 100.0
-    );
-
-    if total_skipped > 0 {
-        println!("   ⏭️  Skipped: {}", total_skipped);
-    }
-
-    // Assert high pass rate (allow some failures for edge cases)
-    let pass_rate = total_passed as f64 / total_tests as f64;
-    if pass_rate < 0.8 {
-        panic!("BLS spec test pass rate too low: {:.1}%", pass_rate * 100.0);
-    } else if pass_rate < 1.0 {
-        println!("\n⚠️  Warning: Some tests failed. Review failures above.");
-    } else {
-        println!("\n🎉 All BLS spec tests passed!");
-    }
-}
-
-/// Test individual verify test case loading
-#[test]
-fn test_load_verify_case() {
-    let base_path = bls_test_path();
-    let test_path = base_path.join("verify/bls/verify_valid_case_195246ee3bd3b6ec/data.yaml");
-
-    if test_path.exists() {
-        let contents = fs::read_to_string(&test_path).expect("Failed to read test file");
-        let test_case: VerifyTestCase =
-            serde_yaml::from_str(&contents).expect("Failed to parse test case");
-
-        assert!(test_case.output);
-        assert!(test_case.input.pubkey.starts_with("0x"));
-        assert!(test_case.input.message.starts_with("0x"));
-        assert!(test_case.input.signature.starts_with("0x"));
-
-        println!("✅ Successfully loaded verify test case");
-    } else {
-        println!("⚠️  Test file not found: {:?}", test_path);
-        println!("   This test will be skipped. See setup instructions in main test.");
-    }
-}
-
-/// Test individual fast aggregate verify test case loading
-#[test]
-fn test_load_fast_aggregate_case() {
-    let base_path = bls_test_path();
-    let test_path = base_path
-        .join("fast_aggregate_verify/bls/fast_aggregate_verify_valid_3d7576f3c0e3570a/data.yaml");
-
-    if test_path.exists() {
-        let contents = fs::read_to_string(&test_path).expect("Failed to read test file");
-        let test_case: FastAggregateVerifyTestCase =
-            serde_yaml::from_str(&contents).expect("Failed to parse test case");
-
-        assert!(test_case.output);
-        assert!(!test_case.input.pubkeys.is_empty());
-        assert!(test_case.input.message.starts_with("0x"));
-        assert!(test_case.input.signature.starts_with("0x"));
-
-        println!("✅ Successfully loaded fast aggregate verify test case");
-    } else {
-        println!("⚠️  Test file not found: {:?}", test_path);
-        println!("   This test will be skipped. See setup instructions in main test.");
-    }
 }

--- a/tests/BLS_TESTING.md
+++ b/tests/BLS_TESTING.md
@@ -1,140 +1,44 @@
-# BLS Specification Compliance Testing
+# BLS Spec-Vector Testing
 
-This project includes comprehensive BLS signature verification testing using official Ethereum consensus specification test vectors.
+BLS signature verification is validated against the official Ethereum consensus
+`fast_aggregate_verify` spec vectors. These tests do **not** test the `blst`
+library itself (already extensively tested) — they pin down that *our* adapter
+(`src/consensus/bls.rs`) uses the correct DST, handles infinity / empty sets per
+spec, and marshals parameters correctly, including the **negative** cases
+(tampered signatures, wrong pubkey sets, infinity pubkeys) that the light-client
+fixture replays never reach.
 
-## Overview
+Sync-committee verification is same-message aggregate, so `fast_aggregate_verify`
+is the only production BLS entry point — and the only path these vectors drive.
 
-The BLS test suite validates our implementation against 40+ official Ethereum test cases covering:
-
-- **Single signature verification** (28 tests)
-- **Fast aggregate verification** (12 tests)  
-- Edge cases (infinity points, invalid inputs, tampered signatures)
-
-## Test Results
-
-✅ **100% Pass Rate**: All 40 test vectors pass successfully
-
-```
-╔═══════════════════════════════════════════════════════╗
-║                  OVERALL SUMMARY                      ║
-╚═══════════════════════════════════════════════════════╝
-📊 Total Tests Run: 40
-   ✅ Passed: 40 (100.0%)
-   ❌ Failed: 0 (0.0%)
-
-🎉 All BLS spec tests passed!
-```
-
-## Quick Start
-
-### 1. Set up test data
+## Running
 
 ```bash
-# Option A: Clone to fixtures (recommended)
-cd tests/fixtures
-git clone https://github.com/ethereum/consensus-spec-tests.git
+cargo test --lib fast_aggregate_verify_spec_vectors
+```
 
-# Option B: Use existing copy via environment variable
+The test (`src/consensus/bls_spec_tests.rs`) walks every
+`fast_aggregate_verify/bls/*` vector and asserts each result strictly — any
+mismatch fails the suite and all mismatches are reported at once.
+
+## Fixtures
+
+The vectors live under
+`tests/fixtures/consensus-spec-tests/tests/general/phase0/bls`. Clone them, or
+point at an existing copy:
+
+```bash
+# Option A: clone into fixtures
+cd tests/fixtures && git clone https://github.com/ethereum/consensus-spec-tests.git
+
+# Option B: use an existing checkout
 export CONSENSUS_SPEC_TESTS_PATH="/path/to/consensus-spec-tests/tests/general/phase0/bls"
 ```
 
-### 2. Run tests
+## Where this fits
 
-```bash
-cargo test --test bls_spec_tests -- --nocapture
-```
-
-## Test Coverage Details
-
-### Single Signature Verification (28 tests)
-- `verify_valid_case_*` - Valid signatures that should pass
-- `verify_tampered_signature_*` - Corrupted signatures that should fail  
-- `verify_wrong_pubkey_*` - Wrong public key that should fail
-- `verify_infinity_pubkey_and_infinity_signature` - Edge case handling
-
-### Fast Aggregate Verification (12 tests)
-- `fast_aggregate_verify_valid_*` - Valid aggregate signatures
-- `fast_aggregate_verify_tampered_*` - Corrupted aggregates that should fail
-- `fast_aggregate_verify_extra_pubkey_*` - Mismatched pubkey counts
-- `fast_aggregate_verify_infinity_*` - Infinity point edge cases
-
-## Security Features
-
-### Secure Path Handling
-- ✅ Environment variable support
-- ✅ Relative path fallbacks
-- ✅ Portable across systems
-
-### Production Ready
-- ✅ Clean error handling
-- ✅ Comprehensive logging
-- ✅ Graceful missing file handling
-- ✅ CI/CD compatible setup
-
-## Implementation Details
-
-Our BLS implementation uses the `blst` library for BLS12-381 operations with:
-
-- **Domain Separation Tag**: `BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_`
-- **Public key validation**: Point-on-curve and subgroup checks
-- **Signature validation**: Proper encoding and point validation  
-- **Edge case handling**: Infinity points and zero signatures
-
-## Integration with Light Client
-
-The BLS verification functions tested here are used throughout the light client:
-
-- **Sync Committee Verification**: `fast_aggregate_verify()` (primary entry point)
-- **Individual Signature Checks**: `verify_bls_signature()` (test-only)
-
-## File Structure
-
-```
-tests/
-├── bls_spec_tests.rs              # Main test runner
-├── fixtures/
-│   ├── README.md                  # Setup instructions
-│   └── consensus-spec-tests/      # Official test vectors
-└── BLS_TESTING.md                 # This documentation
-```
-
-## Continuous Integration
-
-For CI/CD pipelines:
-
-```bash
-# Setup
-git clone https://github.com/ethereum/consensus-spec-tests tests/fixtures/consensus-spec-tests
-
-# Test
-cargo test --test bls_spec_tests
-```
-
-## Troubleshooting
-
-### Missing test data
-```
-❌ Test directory not found
-```
-**Solution**: Follow setup instructions in `tests/fixtures/README.md`
-
-### Environment variable issues
-```bash
-export CONSENSUS_SPEC_TESTS_PATH="/full/path/to/bls/tests"
-```
-
-### Partial test failures
-Individual test files may be missing - the runner gracefully skips missing files and reports statistics for available tests.
-
-## Future Enhancements
-
-Additional BLS test categories available:
-- `aggregate/` - Signature aggregation (5 tests)
-- `aggregate_verify/` - Multi-message verification (5 tests)  
-- `sign/` - Signature generation (10 tests)
-
-These can be added to the test runner as needed for expanded coverage.
-
----
-
-This BLS testing infrastructure ensures our Ethereum light client can safely verify beacon chain signatures with confidence in cryptographic correctness.
+The accept path is also covered in context by the light-client fixture replays
+(a valid sync aggregate is verified as part of processing each update). These
+spec vectors add the reject/edge coverage those replays structurally cannot. See
+[`../src/consensus/README.md`](../src/consensus/README.md) for the full testing
+taxonomy.


### PR DESCRIPTION
Slims the BLS layer down to a thin `blst` adapter, and fixes a conformance gap the slim-down's strict test surfaced. Resolves #76.

## Commit 1 — slim down (`refactor`, no behavior change)
`bls.rs` does not reimplement any BLS cryptography; every curve/pairing op is `blst`. This removes wrapper and test code that surrounded `blst` without covering our adapter's actual decision points:

- Drop `aggregate_then_verify_fallback` (+ `aggregate_pubkeys`) — blst's native `fast_aggregate_verify` is the complete primitive for the same-message case, so the fallback was redundant.
- Drop the `#[cfg(test)]`-only `verify_bls_signature` / `aggregate_signatures` helpers and the unit tests that only re-verified `blst` through them.
- Drop the single-sig `verify/` spec path (not a production path) and the `TestStats`/banner ceremony; keep the `fast_aggregate_verify` official vectors — the one independent check of our adapter's reject/edge behavior — driven through the production path with a **strict, all-must-pass** assertion.
- Rewrite `BLS_TESTING.md` to match.

Net **−786 lines** across the three files.

## Commit 2 — KeyValidate fix (`fix`, conformance)
The strict assertion surfaced a pre-existing gap the old `pass_rate >= 0.8` floor was tolerating: `fast_aggregate_verify` parsed pubkeys **without KeyValidate**, so a set containing the point at infinity (`0xc0..00`) was accepted (blst aggregated it as a no-op and the signature still verified).

- Parse loop now runs `pk.validate()` and returns `false` on failure — a set with an infinity / non-subgroup key is **rejected outright, not filtered**, matching the consensus-spec `FastAggregateVerify`.
- Removes the inconsistent all-zero pubkey filter (never matched canonical infinity; never triggers in production).
- Empty pubkey set still returns `false`, matching the raw-`FastAggregateVerify` vectors (`na_pubkeys_*` both expect `false`).

## Verification
- `fast_aggregate_verify` spec vectors: strict-green, all 12.
- Full suite (69 lib + 3 public-API integration + doc-tests) green; Altair/Bellatrix/Capella replays unaffected by KeyValidate.
- `cargo clippy --all-targets --features test-utils -D warnings` clean.

## Note
Coverage is deliberately the minimal-necessary set: the light-client fixture replays cover the **accept** path in context; the `fast_aggregate_verify` official vectors cover the **reject/edge** path our adapter must get right. The single-sig `verify/` path was not a production path and was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)