### PR TITLE
sync_committee audit round 1 — test hygiene, rotation predicate, bls rename

### DIFF
--- a/src/consensus/bls.rs
+++ b/src/consensus/bls.rs
@@ -12,18 +12,21 @@ use blst::{
 // Ethereum consensus DST (domain separation tag)
 const DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
 
-/// Same-message aggregate verification — the sole BLS entry point.
+/// Same-message aggregate signature verification — the sole BLS entry point.
 ///
-/// All sync committee signature checks go through this. It parses and
-/// `KeyValidate`s the participating pubkeys and parses the aggregate signature,
-/// then defers to blst's native `fast_aggregate_verify`, which is the complete
-/// primitive for the one-message/many-signers case. Any parse failure or
-/// non-success status is a verification failure (`false`).
+/// Named to distinguish it from blst's `Signature::fast_aggregate_verify`, which
+/// it wraps: our version additionally `KeyValidate`s the pubkeys (blst's does
+/// not), so it implements the consensus-spec `FastAggregateVerify`. All sync
+/// committee signature checks go through this.
 ///
-/// Per the consensus-spec `FastAggregateVerify`, an empty pubkey set is invalid,
-/// and each pubkey is `KeyValidate`d — a set containing the infinity pubkey (or
-/// any non-subgroup key) is rejected outright, not filtered.
-pub(crate) fn fast_aggregate_verify(
+/// It parses and `KeyValidate`s the participating pubkeys and parses the
+/// aggregate signature, then defers to blst's native `fast_aggregate_verify` for
+/// the one-message/many-signers pairing. Any parse failure or non-success status
+/// is a verification failure (`false`).
+///
+/// Per the spec, an empty pubkey set is invalid, and a set containing the
+/// infinity pubkey (or any non-subgroup key) is rejected outright, not filtered.
+pub(crate) fn verify_aggregate(
     pubkeys: &[[u8; 48]],
     message: &[u8],
     signature: &[u8; 96],

--- a/src/consensus/bls_spec_tests.rs
+++ b/src/consensus/bls_spec_tests.rs
@@ -12,7 +12,7 @@
 //! Setup: clone consensus-spec-tests into `tests/fixtures/consensus-spec-tests/`
 //! or set `CONSENSUS_SPEC_TESTS_PATH`.
 
-use crate::consensus::bls::fast_aggregate_verify;
+use crate::consensus::bls::verify_aggregate;
 use serde::Deserialize;
 use std::path::PathBuf;
 use std::{env, fs};
@@ -90,7 +90,7 @@ fn fast_aggregate_verify_spec_vectors() {
         let message = parse_hex(&case.input.message);
         let signature: [u8; 96] = fixed(&parse_hex(&case.input.signature));
 
-        let actual = fast_aggregate_verify(&pubkeys, &message, &signature);
+        let actual = verify_aggregate(&pubkeys, &message, &signature);
         if actual != case.output {
             failures.push(format!("{name}: expected {}, got {actual}", case.output));
         }

--- a/src/consensus/processor.rs
+++ b/src/consensus/processor.rs
@@ -196,21 +196,20 @@ impl LightClientProcessor {
             }
         }
 
-        // Rotate when the update's finalized period == store_period + 1
-        // and next committee is known.
+        // Rotate when the update's finalized period == store_period + 1 and the
+        // next committee is known (invariant I-2, via `should_rotate`).
         if let Some(ref finalized_header) = update.finalized_header {
-            let update_finalized_period = self
-                .chain_spec
-                .slot_to_sync_committee_period(finalized_header.slot());
-
-            if update_finalized_period == store_period + 1
-                && self.store.next_sync_committee.is_some()
-            {
+            if sync_committee::should_rotate(
+                finalized_header.slot(),
+                store_period,
+                self.store.next_sync_committee.is_some(),
+                &self.chain_spec,
+            ) {
                 self.store.current_sync_committee = self
                     .store
                     .next_sync_committee
                     .take()
-                    .expect("checked is_some above");
+                    .expect("should_rotate checked next is_some");
                 state_changed = true;
             }
         }
@@ -428,14 +427,19 @@ mod tests {
         let finalized = create_test_beacon_header(next_period_slot);
 
         // Exercise rotation directly (can't do full process_update because
-        // BLS/merkle proofs would fail with synthetic data).
-        let update_fin_period = chain_spec.slot_to_sync_committee_period(finalized.slot);
-        if update_fin_period == store_period + 1 && processor.store.next_sync_committee.is_some() {
+        // BLS/merkle proofs would fail with synthetic data). Uses the same
+        // `should_rotate` predicate as production.
+        if sync_committee::should_rotate(
+            finalized.slot,
+            store_period,
+            processor.store.next_sync_committee.is_some(),
+            &chain_spec,
+        ) {
             processor.store.current_sync_committee = processor
                 .store
                 .next_sync_committee
                 .take()
-                .expect("checked is_some");
+                .expect("should_rotate checked next is_some");
             // Advance finalized header to match (as apply_light_client_update does)
             processor.store.finalized_header = LightClientHeader::altair(finalized);
         }

--- a/src/consensus/sync_committee.rs
+++ b/src/consensus/sync_committee.rs
@@ -138,12 +138,13 @@ pub(crate) fn verify_sync_aggregate(
     )
 }
 
-/// Check if rotation should happen for the given update.
+/// Whether committee rotation should happen for this update (invariant I-2).
 ///
-/// Returns true when the update's finalized period equals `store_period + 1`
-/// and the next committee is known.
-#[cfg(test)]
-pub fn should_rotate(
+/// Rotation happens iff the update's finalized period is exactly one past the
+/// store period and the next committee is known. This is the single predicate
+/// used by both `apply_light_client_update` and the rotation tests — keep it the
+/// only place this condition is expressed.
+pub(crate) fn should_rotate(
     update_finalized_slot: Slot,
     store_period: u64,
     has_next_committee: bool,
@@ -217,58 +218,7 @@ pub fn compute_beacon_domain(
     compute_domain(domain_type, fork_version, genesis_validators_root)
 }
 
-/// Validate a BLS public key (exposed for testing)
-#[cfg(test)]
-pub fn validate_bls_public_key(pubkey_bytes: &BLSPublicKey) -> Result<()> {
-    use blst::{min_pk::PublicKey, BLST_ERROR};
-
-    let pubkey = PublicKey::from_bytes(pubkey_bytes).map_err(|e| match e {
-        BLST_ERROR::BLST_BAD_ENCODING => {
-            Error::InvalidInput("Invalid public key encoding".to_string())
-        }
-        BLST_ERROR::BLST_POINT_NOT_ON_CURVE => {
-            Error::InvalidInput("Public key point not on curve".to_string())
-        }
-        BLST_ERROR::BLST_POINT_NOT_IN_GROUP => {
-            Error::InvalidInput("Public key point not in group".to_string())
-        }
-        _ => Error::InvalidInput(format!("BLS public key error: {:?}", e)),
-    })?;
-
-    if pubkey.validate().is_err() {
-        return Err(Error::InvalidInput("Invalid BLS public key".to_string()));
-    }
-
-    Ok(())
-}
-
-/// Validate a BLS signature (exposed for testing)
-#[cfg(test)]
-pub fn validate_bls_signature(signature_bytes: &BLSSignature) -> Result<()> {
-    use blst::{min_pk::Signature, BLST_ERROR};
-
-    let sig = Signature::from_bytes(signature_bytes).map_err(|e| match e {
-        BLST_ERROR::BLST_BAD_ENCODING => {
-            Error::InvalidInput("Invalid signature encoding".to_string())
-        }
-        BLST_ERROR::BLST_POINT_NOT_ON_CURVE => {
-            Error::InvalidInput("Signature point not on curve".to_string())
-        }
-        BLST_ERROR::BLST_POINT_NOT_IN_GROUP => {
-            Error::InvalidInput("Signature point not in group".to_string())
-        }
-        _ => Error::InvalidInput(format!("BLS signature error: {:?}", e)),
-    })?;
-
-    if sig.validate(false).is_err() {
-        return Err(Error::InvalidInput("Invalid BLS signature".to_string()));
-    }
-
-    Ok(())
-}
-
-/// Verify BLS aggregate signature for sync committee using our tested bls module
-/// Uses fast_aggregate_verify as per Ethereum consensus spec
+/// Verify the sync committee's aggregate signature over the signing root.
 fn verify_sync_committee_signature(
     participating_pubkeys: &[BLSPublicKey],
     message: Root,
@@ -281,12 +231,9 @@ fn verify_sync_committee_signature(
         return Ok(false);
     }
 
-    // Compute the signing root using our spec-compliant function
     let signing_root = compute_signing_root(message, domain)?;
 
-    // Use our tested fast_aggregate_verify from bls module
-    // This passes all official Ethereum consensus spec BLS tests
-    Ok(bls::fast_aggregate_verify(
+    Ok(bls::verify_aggregate(
         participating_pubkeys,
         &signing_root,
         signature,
@@ -321,56 +268,6 @@ fn compute_signing_root(object_root: Root, domain: Domain) -> Result<Root> {
 mod tests {
     use super::*;
     use crate::types::consensus::SyncCommittee;
-
-    /// Aggregate BLS public keys using blst library (test-only helper)
-    fn aggregate_public_keys(pubkeys: &[BLSPublicKey]) -> Result<BLSPublicKey> {
-        use blst::{
-            min_pk::{AggregatePublicKey, PublicKey},
-            BLST_ERROR,
-        };
-
-        if pubkeys.is_empty() {
-            return Err(Error::InvalidInput(
-                "Cannot aggregate empty pubkey list".to_string(),
-            ));
-        }
-
-        let mut aggregate = if let Ok(first_pubkey) = PublicKey::from_bytes(&pubkeys[0]) {
-            AggregatePublicKey::from_public_key(&first_pubkey)
-        } else {
-            return Err(Error::InvalidInput("Invalid first public key".to_string()));
-        };
-
-        for pubkey_bytes in &pubkeys[1..] {
-            let pubkey = PublicKey::from_bytes(pubkey_bytes).map_err(|e| match e {
-                BLST_ERROR::BLST_BAD_ENCODING => {
-                    Error::InvalidInput("Invalid public key encoding".to_string())
-                }
-                BLST_ERROR::BLST_POINT_NOT_ON_CURVE => {
-                    Error::InvalidInput("Public key point not on curve".to_string())
-                }
-                BLST_ERROR::BLST_POINT_NOT_IN_GROUP => {
-                    Error::InvalidInput("Public key point not in group".to_string())
-                }
-                _ => Error::InvalidInput(format!("BLS public key error: {:?}", e)),
-            })?;
-
-            if pubkey.validate().is_err() {
-                return Err(Error::InvalidInput("Invalid BLS public key".to_string()));
-            }
-
-            aggregate.add_public_key(&pubkey, false).map_err(|e| {
-                Error::InvalidInput(format!("Failed to aggregate public key: {:?}", e))
-            })?;
-        }
-
-        let aggregated_pubkey = aggregate.to_public_key();
-        let compressed_bytes = aggregated_pubkey.compress();
-        let mut result = [0u8; 48];
-        result.copy_from_slice(&compressed_bytes);
-
-        Ok(result)
-    }
 
     fn test_committee(agg: u8) -> SyncCommittee {
         SyncCommittee::from_parts(vec![[1u8; 48]; 32], [agg; 48]).unwrap()
@@ -507,92 +404,6 @@ mod tests {
         let different_domain = [10u8; 32];
         let signing_root4 = compute_signing_root(message, different_domain).unwrap();
         assert_ne!(signing_root1, signing_root4);
-    }
-
-    #[test]
-    fn test_blst_sizes() {
-        use blst::min_pk::SecretKey;
-        let sk = SecretKey::key_gen(&[1u8; 32], &[]).unwrap();
-        let pk = sk.sk_to_pk();
-        let pk_bytes = pk.to_bytes();
-        println!("Public key size: {}", pk_bytes.len());
-
-        let message = b"test message";
-        let sig = sk.sign(message, b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_", &[]);
-        let sig_bytes = sig.to_bytes();
-        println!("Signature size: {}", sig_bytes.len());
-    }
-
-    #[test]
-    fn test_bls_key_validation() {
-        // Test with zero key (should fail)
-        let zero_key = [0u8; 48];
-        assert!(validate_bls_public_key(&zero_key).is_err());
-
-        // Test with invalid encoding (should fail)
-        let invalid_key = [255u8; 48];
-        assert!(validate_bls_public_key(&invalid_key).is_err());
-
-        // Generate a valid BLS key pair for testing
-        use blst::min_pk::SecretKey;
-        let sk = SecretKey::key_gen(&[1u8; 32], &[]).unwrap();
-        let pk = sk.sk_to_pk();
-        let pk_bytes = pk.compress();
-
-        // Valid key should pass validation
-        assert!(validate_bls_public_key(&pk_bytes).is_ok());
-    }
-
-    #[test]
-    fn test_bls_signature_validation() {
-        // Test with zero signature (should fail)
-        let zero_sig = [0u8; 96];
-        assert!(validate_bls_signature(&zero_sig).is_err());
-
-        // Test with invalid encoding (should fail)
-        let invalid_sig = [255u8; 96];
-        assert!(validate_bls_signature(&invalid_sig).is_err());
-
-        // Generate a valid BLS signature for testing
-        use blst::min_pk::SecretKey;
-        let sk = SecretKey::key_gen(&[1u8; 32], &[]).unwrap();
-        let message = b"test message";
-        let sig = sk.sign(message, b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_", &[]);
-        let sig_bytes = sig.compress();
-
-        // Valid signature should pass validation
-        assert!(validate_bls_signature(&sig_bytes).is_ok());
-    }
-
-    #[test]
-    fn test_bls_public_key_aggregation() {
-        use blst::min_pk::SecretKey;
-
-        // Generate multiple valid BLS key pairs
-        let mut secret_keys = Vec::new();
-        let mut public_keys = Vec::new();
-
-        for i in 0..3 {
-            let mut seed = [0u8; 32];
-            seed[0] = i as u8 + 1; // Ensure different seeds
-            let sk = SecretKey::key_gen(&seed, &[]).unwrap();
-            let pk = sk.sk_to_pk();
-            secret_keys.push(sk);
-            public_keys.push(pk.compress());
-        }
-
-        // Test aggregation with valid keys
-        let aggregated = aggregate_public_keys(&public_keys);
-        assert!(aggregated.is_ok());
-
-        // Test with empty list (should fail)
-        let empty_keys = Vec::new();
-        assert!(aggregate_public_keys(&empty_keys).is_err());
-
-        // Test with invalid key mixed in (should fail)
-        let mut mixed_keys = public_keys.clone();
-        mixed_keys.push([0u8; 48]); // Invalid zero key
-        assert!(aggregate_public_keys(&mixed_keys).is_err());
     }
 
     #[test]


### PR DESCRIPTION
First pass over `consensus/sync_committee.rs` (809 lines, ~72% of it was `#[cfg(test)]`). Three related cleanups; no production verification behavior changes.

## 1. Drop blst test-only twins
`validate_bls_public_key`, `validate_bls_signature`, and `aggregate_public_keys` — plus their tests and the assertion-free `test_blst_sizes` — were `#[cfg(test)]` wrappers that re-verified **blst** through code we don't ship. Same anti-pattern removed from `bls.rs` in #78. The production BLS path is covered by the `fast_aggregate_verify` spec vectors and the light-client replays; `test_complete_bls_verification_flow` (which drives the real `verify_sync_committee_signature`) is kept.

## 2. Single rotation predicate (invariant I-2)
`should_rotate` was `#[cfg(test)]` and re-implemented the rotation condition that production expressed **inline** in `apply_light_client_update` — so the rotation tests asserted a *twin*, not shipped code (the predicate was triplicated: production inline, `should_rotate`, and a third inline copy in a processor test). Now:
- `should_rotate` is `pub(crate)` — the single place the condition lives.
- `processor::apply_light_client_update` calls it.
- The processor rotation test calls it too.

Behavior-preserving (same predicate, extracted); the rotation tests now exercise production, and the end-to-end replays continue to gate the real path.

## 3. Rename `bls::fast_aggregate_verify` → `bls::verify_aggregate`
Our **validating** wrapper shared the exact name of blst's **non-validating** `Signature::fast_aggregate_verify` — opposite contracts, distinguished only by a `bls::` prefix. That's a readability trap (it tripped up review). The new name + doc make the distinction explicit.

## Verification
- `sync_committee.rs` 809 → 620 lines.
- Full suite green: 65 lib (4 blst-twin tests removed) + 3 public-API integration + doc-tests.
- `cargo clippy --all-targets --features test-utils -D warnings` clean.

Part of the ongoing crate audit. The remaining `sync_committee` findings (triplicated empty-pubkeys check, the never-failing `Result` on `compute_signing_root`) and the cross-module items (validate-once-at-ingest #79; beacon-vs-LC-header-root check) are tracked for follow-up passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)