### PR TITLE
sync_committee: flatten the signature-verify naming ladder + minors

### DIFF
--- a/src/consensus/README.md
+++ b/src/consensus/README.md
@@ -76,6 +76,8 @@ LightClientProcessor::process_update_at_slot(update, current_slot)
               └─ update optimistic header, participation tracking
 ```
 
+**Note:** BLS signature verification answers one thing - did a supermajority of the sync committee we already trust actually sign this new header?
+
 ## Critical Invariants
 
 These properties must hold after every successful `apply_light_client_update`.

--- a/src/consensus/bls.rs
+++ b/src/consensus/bls.rs
@@ -26,7 +26,7 @@ const DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
 ///
 /// Per the spec, an empty pubkey set is invalid, and a set containing the
 /// infinity pubkey (or any non-subgroup key) is rejected outright, not filtered.
-pub(crate) fn verify_aggregate(
+pub(crate) fn verify_aggregate_signature(
     pubkeys: &[[u8; 48]],
     message: &[u8],
     signature: &[u8; 96],

--- a/src/consensus/bls_spec_tests.rs
+++ b/src/consensus/bls_spec_tests.rs
@@ -12,7 +12,7 @@
 //! Setup: clone consensus-spec-tests into `tests/fixtures/consensus-spec-tests/`
 //! or set `CONSENSUS_SPEC_TESTS_PATH`.
 
-use crate::consensus::bls::verify_aggregate;
+use crate::consensus::bls::verify_aggregate_signature;
 use serde::Deserialize;
 use std::path::PathBuf;
 use std::{env, fs};
@@ -90,7 +90,7 @@ fn fast_aggregate_verify_spec_vectors() {
         let message = parse_hex(&case.input.message);
         let signature: [u8; 96] = fixed(&parse_hex(&case.input.signature));
 
-        let actual = verify_aggregate(&pubkeys, &message, &signature);
+        let actual = verify_aggregate_signature(&pubkeys, &message, &signature);
         if actual != case.output {
             failures.push(format!("{name}: expected {}, got {actual}", case.output));
         }

--- a/src/consensus/sync_committee.rs
+++ b/src/consensus/sync_committee.rs
@@ -1,8 +1,9 @@
 use crate::config::ChainSpec;
+use crate::consensus::bls;
 use crate::consensus::merkle::verify_next_sync_committee;
 use crate::error::{Error, Result};
 use crate::types::consensus::{LightClientUpdate, SyncCommittee};
-use crate::types::primitives::{BLSPublicKey, BLSSignature, Domain, ForkVersion, Root, Slot};
+use crate::types::primitives::{BLSSignature, Domain, ForkVersion, Root, Slot};
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 
@@ -125,12 +126,13 @@ pub(crate) fn verify_sync_aggregate(
 
     let domain =
         compute_sync_committee_domain_for_slot(signature_slot, genesis_validators_root, chain_spec);
+    let signing_root = compute_signing_root(attested_header_root, domain);
 
-    Ok(verify_sync_committee_signature(
+    // An empty pubkey set is handled by `verify_aggregate_signature` (returns false).
+    Ok(bls::verify_aggregate_signature(
         &participating_pubkeys,
-        attested_header_root,
+        &signing_root,
         sync_committee_signature,
-        domain,
     ))
 }
 
@@ -212,22 +214,6 @@ pub fn compute_beacon_domain(
     genesis_validators_root: Root,
 ) -> Domain {
     compute_domain(domain_type, fork_version, genesis_validators_root)
-}
-
-/// Verify the sync committee's aggregate signature over the signing root.
-///
-/// An empty pubkey set is handled by `bls::verify_aggregate` (returns `false`).
-fn verify_sync_committee_signature(
-    participating_pubkeys: &[BLSPublicKey],
-    message: Root,
-    signature: &BLSSignature,
-    domain: Domain,
-) -> bool {
-    use crate::consensus::bls;
-
-    let signing_root = compute_signing_root(message, domain);
-
-    bls::verify_aggregate(participating_pubkeys, &signing_root, signature)
 }
 
 /// SigningData container as per Ethereum consensus spec
@@ -443,27 +429,29 @@ mod tests {
         let final_signature = aggregate_sig.to_signature();
         let signature_bytes = final_signature.compress();
 
-        // Verify the signature using our implementation
+        // Verify against the signing root via the production BLS path.
         assert!(
-            verify_sync_committee_signature(&public_keys, message, &signature_bytes, domain),
+            bls::verify_aggregate_signature(&public_keys, &signing_root, &signature_bytes),
             "should verify successfully"
         );
 
-        // Test with wrong message (should fail)
+        // Wrong message -> different signing root -> fails.
         let wrong_message = [43u8; 32];
+        let wrong_message_root = compute_signing_root(wrong_message, domain);
         assert!(
-            !verify_sync_committee_signature(&public_keys, wrong_message, &signature_bytes, domain),
+            !bls::verify_aggregate_signature(&public_keys, &wrong_message_root, &signature_bytes),
             "wrong message should fail verification"
         );
 
-        // Test with wrong domain (should fail)
+        // Wrong domain -> different signing root -> fails.
         let wrong_domain = compute_beacon_domain(
             DOMAIN_BEACON_PROPOSER,
             fork_version,
             genesis_validators_root,
         );
+        let wrong_domain_root = compute_signing_root(message, wrong_domain);
         assert!(
-            !verify_sync_committee_signature(&public_keys, message, &signature_bytes, wrong_domain),
+            !bls::verify_aggregate_signature(&public_keys, &wrong_domain_root, &signature_bytes),
             "wrong domain should fail verification"
         );
     }

--- a/src/consensus/sync_committee.rs
+++ b/src/consensus/sync_committee.rs
@@ -123,19 +123,15 @@ pub(crate) fn verify_sync_aggregate(
 ) -> Result<bool> {
     let participating_pubkeys = committee.participating_pubkeys(sync_committee_bits)?;
 
-    if participating_pubkeys.is_empty() {
-        return Ok(false);
-    }
-
     let domain =
         compute_sync_committee_domain_for_slot(signature_slot, genesis_validators_root, chain_spec);
 
-    verify_sync_committee_signature(
+    Ok(verify_sync_committee_signature(
         &participating_pubkeys,
         attested_header_root,
         sync_committee_signature,
         domain,
-    )
+    ))
 }
 
 /// Whether committee rotation should happen for this update (invariant I-2).
@@ -219,25 +215,19 @@ pub fn compute_beacon_domain(
 }
 
 /// Verify the sync committee's aggregate signature over the signing root.
+///
+/// An empty pubkey set is handled by `bls::verify_aggregate` (returns `false`).
 fn verify_sync_committee_signature(
     participating_pubkeys: &[BLSPublicKey],
     message: Root,
     signature: &BLSSignature,
     domain: Domain,
-) -> Result<bool> {
+) -> bool {
     use crate::consensus::bls;
 
-    if participating_pubkeys.is_empty() {
-        return Ok(false);
-    }
+    let signing_root = compute_signing_root(message, domain);
 
-    let signing_root = compute_signing_root(message, domain)?;
-
-    Ok(bls::verify_aggregate(
-        participating_pubkeys,
-        &signing_root,
-        signature,
-    ))
+    bls::verify_aggregate(participating_pubkeys, &signing_root, signature)
 }
 
 /// SigningData container as per Ethereum consensus spec
@@ -250,7 +240,7 @@ struct SigningData {
 
 /// Compute signing root for BLS signature as per beacon chain specification
 /// Uses TreeHash derive for spec-compliant hash_tree_root computation
-fn compute_signing_root(object_root: Root, domain: Domain) -> Result<Root> {
+fn compute_signing_root(object_root: Root, domain: Domain) -> Root {
     use tree_hash::TreeHash;
 
     let signing_data = SigningData {
@@ -261,7 +251,7 @@ fn compute_signing_root(object_root: Root, domain: Domain) -> Result<Root> {
 
     let mut signing_root = [0u8; 32];
     signing_root.copy_from_slice(root.as_bytes());
-    Ok(signing_root)
+    signing_root
 }
 
 #[cfg(test)]
@@ -389,20 +379,20 @@ mod tests {
         let message = [7u8; 32];
         let domain = [8u8; 32];
 
-        let signing_root1 = compute_signing_root(message, domain).unwrap();
-        let signing_root2 = compute_signing_root(message, domain).unwrap();
+        let signing_root1 = compute_signing_root(message, domain);
+        let signing_root2 = compute_signing_root(message, domain);
 
         // Should be deterministic
         assert_eq!(signing_root1, signing_root2);
 
         // Should change with different message
         let different_message = [9u8; 32];
-        let signing_root3 = compute_signing_root(different_message, domain).unwrap();
+        let signing_root3 = compute_signing_root(different_message, domain);
         assert_ne!(signing_root1, signing_root3);
 
         // Should change with different domain
         let different_domain = [10u8; 32];
-        let signing_root4 = compute_signing_root(message, different_domain).unwrap();
+        let signing_root4 = compute_signing_root(message, different_domain);
         assert_ne!(signing_root1, signing_root4);
     }
 
@@ -431,7 +421,7 @@ mod tests {
             compute_beacon_domain(DOMAIN_SYNC_COMMITTEE, fork_version, genesis_validators_root);
 
         // Compute signing root. (A real-world signing root would be a hashed beaconblockheader + domain)
-        let signing_root = compute_signing_root(message, domain).unwrap();
+        let signing_root = compute_signing_root(message, domain);
 
         // Create individual signatures for the signing root
         // DST uses G2 curve for Ethereum beacon chain
@@ -454,18 +444,17 @@ mod tests {
         let signature_bytes = final_signature.compress();
 
         // Verify the signature using our implementation
-        let verification_result =
-            verify_sync_committee_signature(&public_keys, message, &signature_bytes, domain);
-
-        assert!(verification_result.is_ok());
-        assert!(verification_result.unwrap()); // Should verify successfully
+        assert!(
+            verify_sync_committee_signature(&public_keys, message, &signature_bytes, domain),
+            "should verify successfully"
+        );
 
         // Test with wrong message (should fail)
         let wrong_message = [43u8; 32];
-        let wrong_verification =
-            verify_sync_committee_signature(&public_keys, wrong_message, &signature_bytes, domain);
-        assert!(wrong_verification.is_ok());
-        assert!(!wrong_verification.unwrap()); // Should fail verification
+        assert!(
+            !verify_sync_committee_signature(&public_keys, wrong_message, &signature_bytes, domain),
+            "wrong message should fail verification"
+        );
 
         // Test with wrong domain (should fail)
         let wrong_domain = compute_beacon_domain(
@@ -473,10 +462,10 @@ mod tests {
             fork_version,
             genesis_validators_root,
         );
-        let wrong_domain_verification =
-            verify_sync_committee_signature(&public_keys, message, &signature_bytes, wrong_domain);
-        assert!(wrong_domain_verification.is_ok());
-        assert!(!wrong_domain_verification.unwrap()); // Should fail verification
+        assert!(
+            !verify_sync_committee_signature(&public_keys, message, &signature_bytes, wrong_domain),
+            "wrong domain should fail verification"
+        );
     }
 
     /// Test that domain computation uses the fork version for the epoch of signature_slot.


### PR DESCRIPTION
Continues the `sync_committee` audit. Three commits, all behavior-preserving — no verification logic changed.

## 1. Flatten the signature-verify naming ladder (the meaty one)
The verify chain had three adjacent, near-synonymous names that hid what each layer adds:
`verify_sync_aggregate` → `verify_sync_committee_signature` → `bls::verify_aggregate`.

- **Inline** `verify_sync_committee_signature` into `verify_sync_aggregate`. It was a 2-line private helper whose name duplicated its caller; the signing-root construction is now a visible step in the sequence (`participants → domain → signing root → BLS`).
- **Rename** `bls::verify_aggregate` → `bls::verify_aggregate_signature` — at the BLS layer the name now reads as the crypto operation and no longer collides with the neighbouring `sync_committee` verifies. (It had also shared blst's `Signature::fast_aggregate_verify` name with the *opposite* validation contract — that was the original readability trap.)

The ladder is now three distinct rungs, each named for its layer:
```
verify_update_signature          (which committee, which message)
  → verify_sync_aggregate        (which members, domain, signing root)
    → bls::verify_aggregate_signature   (KeyValidate + pairing)
```
`test_complete_bls_verification_flow` re-pointed to the production `bls::verify_aggregate_signature`.

## 2. Minors (findings 3 & 4 from #80's list)
- Collapse the triplicated empty-pubkeys check — keep only `bls::verify_aggregate_signature`'s authoritative spec handling (empty set → `false`).
- `compute_signing_root` returned `Result` but can't fail (pure `hash_tree_root`) → returns `Root` directly, which lets the caller shed its `Result<bool>` too.

## 3. Docs
One-line note in `consensus/README.md` on what BLS signature verification answers.

## Verification
- Full suite green: 65 lib + 3 public-API integration + doc-tests.
- `cargo clippy --all-targets --features test-utils -D warnings` clean.

Remaining `sync_committee` follow-up is cross-module and tracked separately: validate-once-at-ingest (#79). (The beacon-vs-LC-header-root check turned out to be already handled correctly in `verify_update_signature` — no fix needed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)