### PR TITLE
Make the verification engine time-injectable; move the clock to the facade

### DIFF
--- a/src/consensus/processor.rs
+++ b/src/consensus/processor.rs
@@ -9,7 +9,6 @@ use crate::types::consensus::{
 };
 use crate::types::primitives::Root;
 use crate::types::primitives::Slot;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Light client processor for handling beacon chain updates.
 /// Internal to the crate - not part of the public API.
@@ -56,24 +55,11 @@ impl LightClientProcessor {
         Ok(Self { chain_spec, store })
     }
 
-    /// Process a light client update using wall-clock time for slot validation.
+    /// Process a light client update, validating it against `current_slot`.
     ///
-    /// This is a convenience wrapper that computes `current_slot` from system time.
-    /// For spec-testable behavior, use `process_update_at_slot`.
-    pub(crate) fn process_update(&mut self, update: LightClientUpdate) -> Result<bool> {
-        let current_timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_err(|_| Error::Internal("Failed to get current time".to_string()))?
-            .as_secs();
-        let current_slot = self.chain_spec.timestamp_to_slot(current_timestamp);
-
-        self.process_update_at_slot(update, current_slot)
-    }
-
-    /// Process a light client update with an explicit current slot.
-    ///
-    /// This allows spec tests to inject the fixture's `current_slot` so that
-    /// time-based validation is properly exercised.
+    /// The engine is time-injectable: the caller supplies `current_slot` (the
+    /// `LightClient` facade reads the wall clock; spec tests inject the fixture's
+    /// slot).
     pub(crate) fn process_update_at_slot(
         &mut self,
         update: LightClientUpdate,

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -8,11 +8,12 @@
 
 use crate::config::ChainSpec;
 use crate::consensus::processor::LightClientProcessor;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::types::consensus::{
     BeaconBlockHeader, LightClientBootstrap, LightClientUpdate, SyncCommittee,
 };
 use crate::types::primitives::Slot;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum UpdateOutcome {
@@ -118,10 +119,17 @@ impl LightClient {
     }
 
     /// Verifies and applies an update using wall-clock time, returning what changed.
+    ///
+    /// Reads the system clock to derive `current_slot`; use
+    /// [`process_update_at_slot`](Self::process_update_at_slot) to supply it
+    /// explicitly (tests, custom clocks).
     pub fn process_update(&mut self, update: LightClientUpdate) -> Result<UpdateOutcome> {
-        let before = self.snapshot();
-        let state_changed = self.inner.process_update(update)?;
-        Ok(self.outcome(before, state_changed))
+        let current_timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|_| Error::Internal("Failed to get current time".to_string()))?
+            .as_secs();
+        let current_slot = self.chain_spec().timestamp_to_slot(current_timestamp);
+        self.process_update_at_slot(update, current_slot)
     }
 
     pub fn process_update_at_slot(

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -118,11 +118,6 @@ impl LightClient {
         Ok(Self { inner })
     }
 
-    /// Verifies and applies an update using wall-clock time, returning what changed.
-    ///
-    /// Reads the system clock to derive `current_slot`; use
-    /// [`process_update_at_slot`](Self::process_update_at_slot) to supply it
-    /// explicitly (tests, custom clocks).
     pub fn process_update(&mut self, update: LightClientUpdate) -> Result<UpdateOutcome> {
         let current_timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)


### PR DESCRIPTION
The verification engine reached for the wall clock. `LightClientProcessor::process_update` read `SystemTime::now()` to derive `current_slot` — a non-deterministic `std::time` dependency inside the pure state machine. It was called by exactly one place (the facade) and did nothing but `now()` → `timestamp_to_slot` → `process_update_at_slot`.

Reading the clock is an **ergonomics** concern (a convenience so the caller needn't compute the slot), not a **verification** concern. Verification needs the slot as a *value*; where it comes from is the facade's job.

## Change
- **Engine** (`processor.rs`): delete `process_update`; keep only the time-injectable `process_update_at_slot`. Drop the `std::time` import. `consensus/` is now clock-free and deterministic.
- **Facade** (`light_client.rs`): `process_update` reads the system clock, derives `current_slot`, and delegates to `self.process_update_at_slot(..)`.
- Plus a small comment strip in the facade.

Net: 4 `process_*` methods → 3; the effect lives at the edge (functional core / imperative shell). Behavior-preserving — no public API change.

## Verification
- Full suite green: 65 lib + 3 public-API integration + doc-tests.
- `cargo clippy --all-targets --features test-utils -D warnings` clean.
- No `std::time` / `SystemTime` anywhere under `src/consensus/`.

Groundwork for the processor audit — the engine is now a clean deterministic function of `(update, current_slot, store)`. The companion cleanup of its *return* surface is #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)