### PR TITLE
processor audit — comment cleanup + change-set (closes #82)

### DIFF
--- a/src/consensus/processor.rs
+++ b/src/consensus/processor.rs
@@ -89,8 +89,8 @@ impl LightClientProcessor {
             ));
         }
 
-        // Attested header should be newer than our current finalized header (with some tolerance)
-        // Allow updates from the same slot if they have sync committee updates
+        // Attested header must be newer than our finalized header — or equal, if
+        // the update carries a sync committee (useful for bootstrapping).
         let has_sync_committee = update.has_sync_committee_update();
         let is_slot_acceptable = if has_sync_committee {
             // Allow equal slots if update contains sync committee (useful for bootstrapping)

--- a/src/consensus/processor.rs
+++ b/src/consensus/processor.rs
@@ -10,26 +10,13 @@ use crate::types::consensus::{
 use crate::types::primitives::Root;
 use crate::types::primitives::Slot;
 
-/// Light client processor for handling beacon chain updates.
-/// Internal to the crate - not part of the public API.
 #[derive(Debug)]
 pub(crate) struct LightClientProcessor {
-    /// Chain specification (mainnet or minimal)
     chain_spec: ChainSpec,
-    /// Current trusted state
     store: LightClientStore,
 }
 
 impl LightClientProcessor {
-    /// Create a new light client processor with verified bootstrap.
-    ///
-    /// The `current_sync_committee_branch` proves that `current_sync_committee` is
-    /// correctly embedded in `trusted_header.state_root`. This verification is
-    /// mandatory - there is no unverified constructor path.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the sync committee branch proof fails verification.
     pub(crate) fn new(
         chain_spec: ChainSpec,
         trusted_header: LightClientHeader,
@@ -37,7 +24,6 @@ impl LightClientProcessor {
         current_sync_committee_branch: &[Root],
         genesis_validators_root: Root,
     ) -> Result<Self> {
-        // Verify that the sync committee is properly embedded in the trusted state
         verify_bootstrap_sync_committee(
             &current_sync_committee,
             current_sync_committee_branch,
@@ -55,11 +41,7 @@ impl LightClientProcessor {
         Ok(Self { chain_spec, store })
     }
 
-    /// Process a light client update, validating it against `current_slot`.
-    ///
-    /// The engine is time-injectable: the caller supplies `current_slot` (the
-    /// `LightClient` facade reads the wall clock; spec tests inject the fixture's
-    /// slot).
+    /// The engine is time-injectable
     pub(crate) fn process_update_at_slot(
         &mut self,
         update: LightClientUpdate,
@@ -75,8 +57,6 @@ impl LightClientProcessor {
         self.apply_light_client_update(update)
     }
 
-    /// Validate light client update structure and timing.
-    ///
     /// Takes `current_slot` as an explicit parameter for testability.
     fn validate_light_client_update(
         &self,
@@ -119,8 +99,6 @@ impl LightClientProcessor {
         Ok(())
     }
 
-    /// Verify BLS signature on the light client update.
-    ///
     /// The sync committee signs `hash_tree_root(attested_header.beacon)` — the
     /// beacon block root, not the full `LightClientHeader` root (which includes
     /// execution payload fields starting at Capella).
@@ -155,14 +133,12 @@ impl LightClientProcessor {
         Ok(())
     }
 
-    /// Apply verified light client update to our state
     fn apply_light_client_update(&mut self, update: LightClientUpdate) -> Result<bool> {
         let mut state_changed = false;
 
         // Capture store period BEFORE any finalized-header mutation.
         let store_period = self.store.finalized_sync_committee_period(&self.chain_spec);
 
-        // Update finalized header (verify finality proof first)
         if let Some(ref finalized_header) = update.finalized_header {
             if finalized_header.slot() > self.store.finalized_header.slot() {
                 // The finality branch proves that beacon.hash_tree_root() matches
@@ -218,13 +194,11 @@ impl LightClientProcessor {
             state_changed = true;
         }
 
-        // Update optimistic header if this is better
         if update.attested_header.slot() > self.store.optimistic_header.slot() {
             self.store.optimistic_header = update.attested_header.clone();
             state_changed = true;
         }
 
-        // Update participation tracking
         let participation = update.sync_aggregate.participation_count() as u64;
         self.store.current_max_active_participants = self
             .store
@@ -234,7 +208,6 @@ impl LightClientProcessor {
         Ok(state_changed)
     }
 
-    /// Current finalized header (beacon block header, regardless of fork).
     pub(crate) fn finalized_header(&self) -> &BeaconBlockHeader {
         self.store.finalized_header.beacon()
     }
@@ -400,8 +373,7 @@ mod tests {
         assert!(processor.store.next_sync_committee.is_none());
 
         // Inject a distinguishable "next" committee directly on the store
-        let next =
-            SyncCommittee::from_parts(vec![[0xAA; 48]; 32], [0xBB; 48]).unwrap();
+        let next = SyncCommittee::from_parts(vec![[0xAA; 48]; 32], [0xBB; 48]).unwrap();
         processor.store.next_sync_committee = Some(next.clone());
 
         // Store period is still initial_period (finalized header not yet updated)
@@ -432,7 +404,11 @@ mod tests {
 
         // Assertions: store state is correct after rotation
         assert_eq!(
-            processor.store.current_sync_committee.aggregate_pubkey().as_ref(),
+            processor
+                .store
+                .current_sync_committee
+                .aggregate_pubkey()
+                .as_ref(),
             &[0xBB; 48],
             "store current committee should be what was next"
         );

--- a/src/consensus/processor.rs
+++ b/src/consensus/processor.rs
@@ -16,6 +16,16 @@ pub(crate) struct LightClientProcessor {
     store: LightClientStore,
 }
 
+/// What a processed update changed in the store. The engine reports this
+/// directly; the `LightClient` facade maps it to the public `UpdateOutcome`.
+#[derive(Default)]
+pub(crate) struct UpdateChanges {
+    pub finalized_updated: bool,
+    pub optimistic_updated: bool,
+    pub rotated: bool,
+    pub next_committee_learned: bool,
+}
+
 impl LightClientProcessor {
     pub(crate) fn new(
         chain_spec: ChainSpec,
@@ -46,7 +56,7 @@ impl LightClientProcessor {
         &mut self,
         update: LightClientUpdate,
         current_slot: Slot,
-    ) -> Result<bool> {
+    ) -> Result<UpdateChanges> {
         // Validate basic update properties: fail fast principle
         self.validate_light_client_update(&update, current_slot)?;
 
@@ -133,8 +143,8 @@ impl LightClientProcessor {
         Ok(())
     }
 
-    fn apply_light_client_update(&mut self, update: LightClientUpdate) -> Result<bool> {
-        let mut state_changed = false;
+    fn apply_light_client_update(&mut self, update: LightClientUpdate) -> Result<UpdateChanges> {
+        let mut changes = UpdateChanges::default();
 
         // Capture store period BEFORE any finalized-header mutation.
         let store_period = self.store.finalized_sync_committee_period(&self.chain_spec);
@@ -154,13 +164,11 @@ impl LightClientProcessor {
                 )?;
 
                 self.store.finalized_header = finalized_header.clone();
-                state_changed = true;
+                changes.finalized_updated = true;
             }
-        }
 
-        // Rotate when the update's finalized period == store_period + 1 and the
-        // next committee is known (invariant I-2, via `should_rotate`).
-        if let Some(ref finalized_header) = update.finalized_header {
+            // Rotate when the update's finalized period == store_period + 1 and the
+            // next committee is known (invariant I-2, via `should_rotate`).
             if sync_committee::should_rotate(
                 finalized_header.slot(),
                 store_period,
@@ -172,7 +180,7 @@ impl LightClientProcessor {
                     .next_sync_committee
                     .take()
                     .expect("should_rotate checked next is_some");
-                state_changed = true;
+                changes.rotated = true;
             }
         }
 
@@ -191,12 +199,12 @@ impl LightClientProcessor {
             &self.chain_spec,
         )? {
             self.store.next_sync_committee = Some(verified);
-            state_changed = true;
+            changes.next_committee_learned = true;
         }
 
         if update.attested_header.slot() > self.store.optimistic_header.slot() {
             self.store.optimistic_header = update.attested_header.clone();
-            state_changed = true;
+            changes.optimistic_updated = true;
         }
 
         let participation = update.sync_aggregate.participation_count() as u64;
@@ -205,7 +213,7 @@ impl LightClientProcessor {
             .current_max_active_participants
             .max(participation);
 
-        Ok(state_changed)
+        Ok(changes)
     }
 
     pub(crate) fn finalized_header(&self) -> &BeaconBlockHeader {

--- a/src/consensus/sync_committee.rs
+++ b/src/consensus/sync_committee.rs
@@ -138,7 +138,7 @@ pub(crate) fn verify_sync_aggregate(
 
 /// Whether committee rotation should happen for this update (invariant I-2).
 ///
-/// Rotation happens iff the update's finalized period is exactly one past the
+/// Rotation happens if the update's finalized period is exactly one past the
 /// store period and the next committee is known. This is the single predicate
 /// used by both `apply_light_client_update` and the rotation tests — keep it the
 /// only place this condition is expressed.

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -7,7 +7,7 @@
 //! for usage, the trust model, and a full example.
 
 use crate::config::ChainSpec;
-use crate::consensus::processor::LightClientProcessor;
+use crate::consensus::processor::{LightClientProcessor, UpdateChanges};
 use crate::error::{Error, Result};
 use crate::types::consensus::{
     BeaconBlockHeader, LightClientBootstrap, LightClientUpdate, SyncCommittee,
@@ -46,9 +46,10 @@ impl LightClient {
         update: LightClientUpdate,
         current_slot: Slot,
     ) -> Result<UpdateOutcome> {
-        let before = self.snapshot();
-        let state_changed = self.inner.process_update_at_slot(update, current_slot)?;
-        Ok(self.outcome(before, state_changed))
+        Ok(self
+            .inner
+            .process_update_at_slot(update, current_slot)?
+            .into())
     }
 
     #[inline]
@@ -83,26 +84,6 @@ impl LightClient {
     pub fn chain_spec(&self) -> &ChainSpec {
         self.inner.chain_spec()
     }
-
-    fn snapshot(&self) -> StateSnapshot {
-        StateSnapshot {
-            finalized_slot: self.inner.finalized_header().slot,
-            optimistic_slot: self.inner.optimistic_header().slot,
-            period: self.inner.current_period(),
-        }
-    }
-
-    fn outcome(&self, before: StateSnapshot, state_changed: bool) -> UpdateOutcome {
-        if !state_changed {
-            return UpdateOutcome::NoChange;
-        }
-        let after = self.snapshot();
-        UpdateOutcome::StateAdvanced {
-            finalized_updated: after.finalized_slot != before.finalized_slot,
-            optimistic_updated: after.optimistic_slot != before.optimistic_slot,
-            sync_committee_updated: after.period != before.period,
-        }
-    }
 }
 
 impl std::fmt::Debug for LightClient {
@@ -116,19 +97,13 @@ impl std::fmt::Debug for LightClient {
     }
 }
 
-/// Used to diff an update's effect.
-struct StateSnapshot {
-    finalized_slot: Slot,
-    optimistic_slot: Slot,
-    period: u64,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum UpdateOutcome {
     StateAdvanced {
         finalized_updated: bool,
         optimistic_updated: bool,
-        sync_committee_updated: bool,
+        rotated: bool,
+        next_committee_learned: bool,
     },
     NoChange,
 }
@@ -162,13 +137,36 @@ impl UpdateOutcome {
     }
 
     #[inline]
-    pub fn sync_committee_updated(&self) -> bool {
+    pub fn rotated(&self) -> bool {
+        matches!(
+            self,
+            UpdateOutcome::StateAdvanced { rotated: true, .. }
+        )
+    }
+
+    #[inline]
+    pub fn next_committee_learned(&self) -> bool {
         matches!(
             self,
             UpdateOutcome::StateAdvanced {
-                sync_committee_updated: true,
+                next_committee_learned: true,
                 ..
             }
         )
+    }
+}
+
+impl From<UpdateChanges> for UpdateOutcome {
+    fn from(c: UpdateChanges) -> Self {
+        if !(c.finalized_updated || c.optimistic_updated || c.rotated || c.next_committee_learned) {
+            UpdateOutcome::NoChange
+        } else {
+            UpdateOutcome::StateAdvanced {
+                finalized_updated: c.finalized_updated,
+                optimistic_updated: c.optimistic_updated,
+                rotated: c.rotated,
+                next_committee_learned: c.next_committee_learned,
+            }
+        }
     }
 }


### PR DESCRIPTION
First processor-audit PR. Behavior-preserving for finalized/optimistic; **closes #82**.

## Commits
1. **Comment trim** — remove obvious struct/field/step comments; **keep** the two consensus-critical ones (why the finality branch uses the beacon root, not the full `LightClientHeader` root; the I-2 rotation gating). Drop some in-progress rename TODOs.
2. **Change-set (#82)** — `apply_light_client_update` now returns a precise `UpdateChanges { finalized_updated, optimistic_updated, rotated, next_committee_learned }` instead of a bare `bool`. The facade maps it straight to `UpdateOutcome` via `From` — `StateSnapshot`/`snapshot()`/`outcome()` deleted (no more before/after diffing). The all-false `StateAdvanced` wart is now structurally impossible.
   - `UpdateOutcome` gains `next_committee_learned`; `sync_committee_updated` → `rotated`.
   - **`rotated` is semantically sharper**: it means the committee was actually replaced (`should_rotate` fired), not merely "the finalized period number changed" (the old flag reported `true` even when no rotation happened). No consumer relied on the old behavior.
   - Folded the two `if let Some(finalized_header)` blocks in `apply` into one.
3. **Doc fix** — `validate` said "with some tolerance"; there is none.

## Verification
- Full suite green: 56 lib + 3 public-API integration + doc-tests.
- `cargo clippy --all-targets --features test-utils -D warnings` clean.

Note: `next_committee_learned` and the sharpened `rotated` are not yet asserted by a test (the replay only checks finalized/optimistic). Left for post-v0 per the current trim philosophy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)