### PR TITLE
processor cleanup + types comment trim

### DIFF
--- a/src/consensus/processor.rs
+++ b/src/consensus/processor.rs
@@ -16,8 +16,7 @@ pub(crate) struct LightClientProcessor {
     store: LightClientStore,
 }
 
-/// What a processed update changed in the store. The engine reports this
-/// directly; the `LightClient` facade maps it to the public `UpdateOutcome`.
+/// What a processed update changed in the store.
 #[derive(Default)]
 pub(crate) struct UpdateChanges {
     pub finalized_updated: bool,
@@ -51,29 +50,25 @@ impl LightClientProcessor {
         Ok(Self { chain_spec, store })
     }
 
-    /// The engine is time-injectable
+    /// The processor is time-injectable
     pub(crate) fn process_update_at_slot(
         &mut self,
         update: LightClientUpdate,
         current_slot: Slot,
     ) -> Result<UpdateChanges> {
-        // Validate basic update properties: fail fast principle
         self.validate_light_client_update(&update, current_slot)?;
 
-        // Verify sync committee signature
         self.verify_update_signature(&update)?;
 
-        // Apply the update to our store
         self.apply_light_client_update(update)
     }
 
-    /// Takes `current_slot` as an explicit parameter for testability.
+    /// Validate basic update properties: fail fast principle
     fn validate_light_client_update(
         &self,
         update: &LightClientUpdate,
         current_slot: Slot,
     ) -> Result<()> {
-        // Basic validation: signature_slot > attested_header.slot, supermajority participation
         update.validate_basic(&self.store.current_sync_committee)?;
 
         // Validate header-local consistency (execution branch for Capella+).
@@ -82,21 +77,17 @@ impl LightClientProcessor {
             validate_light_client_header(finalized)?;
         }
 
-        // Spec: current_slot >= signature_slot (strict, no tolerance)
         if update.signature_slot > current_slot {
             return Err(Error::InvalidInput(
                 "Update signature slot is in the future".to_string(),
             ));
         }
 
-        // Attested header must be newer than our finalized header — or equal, if
-        // the update carries a sync committee (useful for bootstrapping).
+        // Attested header must be newer than our finalized header — or equal if the update carries a sync committee (useful for bootstrapping).
         let has_sync_committee = update.has_sync_committee_update();
         let is_slot_acceptable = if has_sync_committee {
-            // Allow equal slots if update contains sync committee (useful for bootstrapping)
             update.attested_header.slot() >= self.store.finalized_header.slot()
         } else {
-            // Regular updates must be strictly newer
             update.attested_header.slot() > self.store.finalized_header.slot()
         };
 
@@ -167,8 +158,7 @@ impl LightClientProcessor {
                 changes.finalized_updated = true;
             }
 
-            // Rotate when the update's finalized period == store_period + 1 and the
-            // next committee is known (invariant I-2, via `should_rotate`).
+            // Rotate on finalized-period advance (invariant I-2; see consensus/README).
             if sync_committee::should_rotate(
                 finalized_header.slot(),
                 store_period,
@@ -184,13 +174,8 @@ impl LightClientProcessor {
             }
         }
 
-        // Learn next sync committee AFTER finalized-header update and rotation.
-        // We derive the period from the store's (now-updated) finalized header so
-        // that:
-        //   - if finality advances but rotation can't happen (next unknown), we
-        //     learn next relative to the new finalized period;
-        //   - if rotation happened, we begin learning the subsequent period's
-        //     committee.
+        // Learn next AFTER the finalized-header update + rotation, using the now-
+        // updated finalized period (see consensus/README data flow).
         let finalized_period = self.store.finalized_sync_committee_period(&self.chain_spec);
         if let Some(verified) = sync_committee::learn_next_sync_committee_from_update(
             &update,
@@ -278,44 +263,7 @@ mod tests {
     }
 
     #[test]
-    fn test_light_client_processor_creation() {
-        let bootstrap = load_altair_bootstrap();
-        let chain_spec = crate::config::ChainSpec::minimal();
-        let expected_slot = bootstrap.header.slot();
-
-        let processor = LightClientProcessor::new(
-            chain_spec,
-            bootstrap.header.clone(),
-            bootstrap.current_sync_committee,
-            &bootstrap.current_sync_committee_branch,
-            bootstrap.genesis_validators_root,
-        )
-        .unwrap();
-
-        assert_eq!(processor.finalized_header().slot, expected_slot);
-        assert_eq!(processor.optimistic_header().slot, expected_slot);
-    }
-
-    #[test]
-    fn test_light_client_processor_rejects_invalid_branch() {
-        let bootstrap = load_altair_bootstrap();
-        let chain_spec = crate::config::ChainSpec::minimal();
-
-        let empty_branch: Vec<Root> = vec![];
-
-        let result = LightClientProcessor::new(
-            chain_spec,
-            bootstrap.header.clone(),
-            bootstrap.current_sync_committee,
-            &empty_branch,
-            bootstrap.genesis_validators_root,
-        );
-
-        assert!(result.is_err(), "Should reject invalid branch proof");
-    }
-
-    #[test]
-    fn test_light_client_update_validation() {
+    fn test_rejects_stale_update() {
         let bootstrap = load_altair_bootstrap();
         let chain_spec = crate::config::ChainSpec::minimal();
         let bootstrap_slot = bootstrap.header.slot();

--- a/src/types/consensus.rs
+++ b/src/types/consensus.rs
@@ -297,18 +297,22 @@ impl SyncCommittee {
     pub fn hash_tree_root(&self) -> Root {
         let agg = self.aggregate_pubkey.clone();
         match self.pubkeys.len() {
-            512 => CommitteeRoot512 {
-                pubkeys: FixedVector::new(self.pubkeys.clone()).expect("len checked"),
-                aggregate_pubkey: agg,
+            512 => {
+                CommitteeRoot512 {
+                    pubkeys: FixedVector::new(self.pubkeys.clone()).expect("len checked"),
+                    aggregate_pubkey: agg,
+                }
+                .tree_hash_root()
+                .0
             }
-            .tree_hash_root()
-            .0,
-            32 => CommitteeRoot32 {
-                pubkeys: FixedVector::new(self.pubkeys.clone()).expect("len checked"),
-                aggregate_pubkey: agg,
+            32 => {
+                CommitteeRoot32 {
+                    pubkeys: FixedVector::new(self.pubkeys.clone()).expect("len checked"),
+                    aggregate_pubkey: agg,
+                }
+                .tree_hash_root()
+                .0
             }
-            .tree_hash_root()
-            .0,
             n => unreachable!("sync committee is 32 or 512 members, got {n}"),
         }
     }
@@ -413,24 +417,16 @@ impl SyncAggregate {
     }
 }
 
-/// Light client update containing all data needed for verification.
-///
-/// Headers are fork-aware [`LightClientHeader`] values.
+/// [`LightClientHeader`]s are fork aware.
 #[derive(Debug, Clone, PartialEq)]
 pub struct LightClientUpdate {
-    /// The header being attested to (fork-aware).
     pub attested_header: LightClientHeader,
-    /// The finalized header (fork-aware), if present.
     pub finalized_header: Option<LightClientHeader>,
-    /// Merkle proof for finalized header
     pub finality_branch: Vec<Root>,
-    /// Next sync committee (if committee changes)
     pub next_sync_committee: Option<SyncCommittee>,
-    /// Merkle proof for next sync committee
     pub next_sync_committee_branch: Vec<Root>,
-    /// Sync committee aggregate signature and participation
     pub sync_aggregate: SyncAggregate,
-    /// Signature slot (should be attested_header.slot + 1)
+    /// Should be attested_header.slot + 1
     pub signature_slot: Slot,
 }
 
@@ -562,7 +558,12 @@ impl LightClientBootstrap {
         sync_committee_size: usize,
         genesis_validators_root: Root,
     ) -> Result<Self> {
-        crate::types::ssz::decode_bootstrap(bytes, fork, sync_committee_size, genesis_validators_root)
+        crate::types::ssz::decode_bootstrap(
+            bytes,
+            fork,
+            sync_committee_size,
+            genesis_validators_root,
+        )
     }
 
     /// Create a new bootstrap package from a `BeaconBlockHeader` (convenience, wraps as Altair).
@@ -684,12 +685,18 @@ mod tests {
 
         // Exactly 2/3 passes.
         let mut participation = vec![false; 32];
-        participation.iter_mut().take(threshold).for_each(|p| *p = true);
+        participation
+            .iter_mut()
+            .take(threshold)
+            .for_each(|p| *p = true);
         assert!(committee.has_supermajority_participation(&participation));
 
         // One below 2/3 fails.
         let mut participation = vec![false; 32];
-        participation.iter_mut().take(threshold - 1).for_each(|p| *p = true);
+        participation
+            .iter_mut()
+            .take(threshold - 1)
+            .for_each(|p| *p = true);
         assert!(!committee.has_supermajority_participation(&participation));
 
         // Full participation passes.

--- a/src/types/ssz.rs
+++ b/src/types/ssz.rs
@@ -171,7 +171,9 @@ fn raw_beacon_only_update_to_pub<N: Unsigned>(
     )
 }
 
-fn raw_capella_update_to_pub<N: Unsigned>(raw: RawCapellaLightClientUpdate<N>) -> LightClientUpdate {
+fn raw_capella_update_to_pub<N: Unsigned>(
+    raw: RawCapellaLightClientUpdate<N>,
+) -> LightClientUpdate {
     let finalized_header = (raw.finalized_header.beacon.slot != 0)
         .then_some(LightClientHeader::Capella(raw.finalized_header));
 
@@ -204,6 +206,8 @@ fn decode_capella_update<N: Unsigned>(bytes: &[u8]) -> crate::error::Result<Ligh
     Ok(raw_capella_update_to_pub(raw))
 }
 
+/// SSZ-decode a light client update for `fork` + `sync_committee_size`
+/// (see [`LightClientUpdate::from_ssz`] for the wire-layout contract).
 pub(crate) fn decode_update(
     bytes: &[u8],
     fork: Fork,
@@ -277,9 +281,7 @@ fn decode_err(e: ssz::DecodeError) -> crate::error::Error {
 }
 
 fn bad_size(n: usize) -> crate::error::Error {
-    crate::error::Error::InvalidInput(format!(
-        "sync_committee_size must be 32 or 512, got {n}"
-    ))
+    crate::error::Error::InvalidInput(format!("sync_committee_size must be 32 or 512, got {n}"))
 }
 
 fn unsupported(fork: Fork) -> crate::error::Error {


### PR DESCRIPTION
Cleanup pass over `processor.rs` (+ a comment trim in `types/consensus.rs` / `types/ssz.rs`). Behavior-preserving.

## Commits
1. **processor cleanup** — drop the redundant creation smoke test and `rejects_invalid_branch` (empty-branch rejection is already covered by `merkle::test_bootstrap_verification_structure`); rename `update_validation` → `test_rejects_stale_update` (was name-clashing with the `types/consensus` test). Thin the I-2 / learn-AFTER narrative comments toward the README, keep the line-coupled guardrails (beacon-root rationale, capture-`store_period`-BEFORE). Two high-value white-box tests remain.
2. **types comment trim** — trim the `decode_update` doc (it duplicated the public `LightClientUpdate::from_ssz` contract verbatim), remove obvious comments, drop in-progress TODOs.

Filed [#87](https://github.com/EchoAlice/eth-light-client/issues/87) during this pass — the stale-update `Err`-vs-`Ok(NoChange)` semantics question.

## Verification
- Full suite green: 54 lib + 3 integration + doc-tests.
- `cargo clippy --all-targets --features test-utils -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)