### PR TITLE
types/consensus audit — trim surface, remove scaffolding, pair branches, comment sweep

### DIFF
--- a/src/consensus/processor.rs
+++ b/src/consensus/processor.rs
@@ -73,8 +73,8 @@ impl LightClientProcessor {
 
         // Validate header-local consistency (execution branch for Capella+).
         validate_light_client_header(&update.attested_header)?;
-        if let Some(ref finalized) = update.finalized_header {
-            validate_light_client_header(finalized)?;
+        if let Some(ref finalized) = update.finalized {
+            validate_light_client_header(&finalized.header)?;
         }
 
         if update.signature_slot > current_slot {
@@ -140,27 +140,27 @@ impl LightClientProcessor {
         // Capture store period BEFORE any finalized-header mutation.
         let store_period = self.store.finalized_sync_committee_period(&self.chain_spec);
 
-        if let Some(ref finalized_header) = update.finalized_header {
-            if finalized_header.slot() > self.store.finalized_header.slot() {
+        if let Some(ref finalized) = update.finalized {
+            if finalized.header.slot() > self.store.finalized_header.slot() {
                 // The finality branch proves that beacon.hash_tree_root() matches
                 // finalized_checkpoint.root in the attested state — use the beacon
                 // root, not the full LightClientHeader root.
-                let finalized_header_root = finalized_header.beacon().hash_tree_root()?;
+                let finalized_header_root = finalized.header.beacon().hash_tree_root()?;
                 verify_finality_branch(
                     &finalized_header_root,
-                    &update.finality_branch,
+                    &finalized.branch,
                     update.attested_header.slot(),
                     update.attested_header.state_root(),
                     &self.chain_spec,
                 )?;
 
-                self.store.finalized_header = finalized_header.clone();
+                self.store.finalized_header = finalized.header.clone();
                 changes.finalized_updated = true;
             }
 
             // Rotate on finalized-period advance (invariant I-2; see consensus/README).
             if sync_committee::should_rotate(
-                finalized_header.slot(),
+                finalized.header.slot(),
                 store_period,
                 self.store.next_sync_committee.is_some(),
                 &self.chain_spec,

--- a/src/consensus/processor.rs
+++ b/src/consensus/processor.rs
@@ -192,12 +192,6 @@ impl LightClientProcessor {
             changes.optimistic_updated = true;
         }
 
-        let participation = update.sync_aggregate.participation_count() as u64;
-        self.store.current_max_active_participants = self
-            .store
-            .current_max_active_participants
-            .max(participation);
-
         Ok(changes)
     }
 

--- a/src/consensus/sync_committee.rs
+++ b/src/consensus/sync_committee.rs
@@ -82,7 +82,7 @@ pub(crate) fn learn_next_sync_committee_from_update(
     }
 
     let update_period = chain_spec.slot_to_sync_committee_period(update.attested_header.slot());
-    let attested_next_committee = update.next_sync_committee.as_ref().unwrap();
+    let next = update.next_sync_committee.as_ref().unwrap();
 
     // Defensive invariant: only learn `next_sync_committee` when
     // `attested_period == finalized_period` (store period). This should
@@ -97,14 +97,14 @@ pub(crate) fn learn_next_sync_committee_from_update(
 
     // Verify the merkle branch proof
     verify_next_sync_committee(
-        attested_next_committee,
-        &update.next_sync_committee_branch,
+        &next.committee,
+        &next.branch,
         update.attested_header.slot(),
         update.attested_header.state_root(),
         chain_spec,
     )?;
 
-    Ok(Some(attested_next_committee.clone()))
+    Ok(Some(next.committee.clone()))
 }
 
 /// Verify a sync aggregate signature.

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -138,10 +138,7 @@ impl UpdateOutcome {
 
     #[inline]
     pub fn rotated(&self) -> bool {
-        matches!(
-            self,
-            UpdateOutcome::StateAdvanced { rotated: true, .. }
-        )
+        matches!(self, UpdateOutcome::StateAdvanced { rotated: true, .. })
     }
 
     #[inline]

--- a/src/types/consensus.rs
+++ b/src/types/consensus.rs
@@ -8,8 +8,8 @@ use ssz_types::{FixedVector, VariableList};
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 
-/// Beacon block header as per consensus specs
-/// Uses TreeHash derive for proper SSZ hash_tree_root computation
+pub type PubkeyBytes = FixedVector<u8, U48>;
+
 #[derive(Debug, Clone, PartialEq, Eq, TreeHash, Encode, Decode)]
 pub struct BeaconBlockHeader {
     pub slot: Slot,
@@ -50,19 +50,7 @@ impl BeaconBlockHeader {
     }
 }
 
-// =============================================================================
-// LightClientHeader (fork-aware)
-// =============================================================================
-
-/// Fork-aware light client header.
-///
-/// Each consensus fork defines its own `LightClientHeader` shape.
-/// In Altair and Bellatrix the header contains only a `BeaconBlockHeader`.
-/// Later forks (Capella onward) add execution payload header fields;
-/// those variants will be added here as the library gains support.
-///
-/// Verification logic accesses the inner `BeaconBlockHeader` through
-/// [`beacon()`](Self::beacon), keeping the pipeline fork-agnostic.
+/// Verification logic accesses the inner `BeaconBlockHeader` through [`beacon()`](Self::beacon), keeping the pipeline fork-agnostic.
 #[derive(Debug, Clone, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 pub enum LightClientHeader {
@@ -75,36 +63,23 @@ pub enum LightClientHeader {
     // Fulu(FuluLightClientHeader),
 }
 
-/// Altair light client header — beacon header only.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AltairLightClientHeader {
     pub beacon: BeaconBlockHeader,
 }
 
-/// Bellatrix light client header — same shape as Altair.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BellatrixLightClientHeader {
     pub beacon: BeaconBlockHeader,
 }
 
-/// Capella light client header — adds execution payload.
-///
-/// Starting at Capella, the `LightClientHeader` includes an execution
-/// payload header and a merkle branch proving it is embedded in
-/// `beacon.body_root` at `EXECUTION_PAYLOAD_GINDEX` (25).
 #[derive(Debug, Clone, PartialEq, Encode, Decode, TreeHash)]
 pub struct CapellaLightClientHeader {
     pub beacon: BeaconBlockHeader,
     pub execution: ExecutionPayloadHeaderCapella,
-    /// Merkle branch proving `execution` is at gindex 25 in `beacon.body_root`.
-    /// Fixed length = floorlog2(EXECUTION_PAYLOAD_GINDEX) = floorlog2(25) = 4.
     pub execution_branch: FixedVector<Root, U4>,
 }
 
-/// Execution payload header for Capella (15 fields).
-///
-/// This is the execution-layer block header embedded in the beacon block.
-/// Capella adds `withdrawals_root` compared to Bellatrix.
 #[derive(Debug, Clone, PartialEq, Encode, Decode, TreeHash)]
 pub struct ExecutionPayloadHeaderCapella {
     pub parent_hash: Root,
@@ -117,7 +92,6 @@ pub struct ExecutionPayloadHeaderCapella {
     pub gas_limit: u64,
     pub gas_used: u64,
     pub timestamp: u64,
-    /// `ByteList[32]` — the 32-byte bound is enforced by the `VariableList` type.
     pub extra_data: VariableList<u8, U32>,
     pub base_fee_per_gas: U256,
     pub block_hash: Root,
@@ -125,6 +99,7 @@ pub struct ExecutionPayloadHeaderCapella {
     pub withdrawals_root: Root,
 }
 
+// TODO: Does this method make sense?
 impl ExecutionPayloadHeaderCapella {
     /// SSZ `hash_tree_root` as a [`Root`] — thin wrapper over the derived
     /// [`TreeHash`] impl (the field-by-field merkleization is now generated).
@@ -133,23 +108,12 @@ impl ExecutionPayloadHeaderCapella {
     }
 }
 
-/// Deneb light client header — same shape as Capella, with a Deneb execution payload.
-///
-/// The execution branch length is unchanged: `EXECUTION_PAYLOAD_GINDEX` (25) is
-/// constant from Capella through Electra, so `floorlog2(25) = 4`.
 #[derive(Debug, Clone, PartialEq, Encode, Decode, TreeHash)]
 pub struct DenebLightClientHeader {
     pub beacon: BeaconBlockHeader,
     pub execution: ExecutionPayloadHeaderDeneb,
-    /// Merkle branch proving `execution` is at gindex 25 in `beacon.body_root`.
     pub execution_branch: FixedVector<Root, U4>,
 }
-
-/// Execution payload header for Deneb (17 fields).
-///
-/// Adds `blob_gas_used` and `excess_blob_gas` to the Capella shape, increasing
-/// the SSZ container field count from 15 to 17. Merkleization pads to 32 leaves
-/// (next power of two ≥ 17), which differs from Capella's 16-leaf padding.
 #[derive(Debug, Clone, PartialEq, Encode, Decode, TreeHash)]
 pub struct ExecutionPayloadHeaderDeneb {
     pub parent_hash: Root,
@@ -162,7 +126,6 @@ pub struct ExecutionPayloadHeaderDeneb {
     pub gas_limit: u64,
     pub gas_used: u64,
     pub timestamp: u64,
-    /// `ByteList[32]` — the 32-byte bound is enforced by the `VariableList` type.
     pub extra_data: VariableList<u8, U32>,
     pub base_fee_per_gas: U256,
     pub block_hash: Root,
@@ -172,6 +135,7 @@ pub struct ExecutionPayloadHeaderDeneb {
     pub excess_blob_gas: u64,
 }
 
+// TODO: Does this method make sense?
 impl ExecutionPayloadHeaderDeneb {
     /// SSZ `hash_tree_root` as a [`Root`] — thin wrapper over the derived
     /// [`TreeHash`] impl.
@@ -181,11 +145,13 @@ impl ExecutionPayloadHeaderDeneb {
 }
 
 impl LightClientHeader {
+    // TODO: Does this method make sense?
     /// Wrap a `BeaconBlockHeader` as an Altair-era header.
     pub(crate) fn altair(beacon: BeaconBlockHeader) -> Self {
         Self::Altair(AltairLightClientHeader { beacon })
     }
 
+    // TODO: Should we delete?
     /// Wrap a `BeaconBlockHeader` as a Bellatrix-era header.
     pub(crate) fn bellatrix(beacon: BeaconBlockHeader) -> Self {
         Self::Bellatrix(BellatrixLightClientHeader { beacon })
@@ -201,30 +167,15 @@ impl LightClientHeader {
         }
     }
 
-    /// The header's slot.
     pub fn slot(&self) -> Slot {
         self.beacon().slot
     }
 
-    /// The header's state root.
     pub fn state_root(&self) -> &Root {
         &self.beacon().state_root
     }
 }
 
-// =============================================================================
-// SyncCommittee
-// =============================================================================
-
-/// A single BLS public key as SSZ bytes (`Vector[byte, 48]`).
-pub type PubkeyBytes = FixedVector<u8, U48>;
-
-/// Sync committee: a spec-sized list of BLS pubkeys plus the aggregate.
-///
-/// The list length *is* the committee size (32 minimal / 512 mainnet), so there
-/// is no zero-padding (#21). The SSZ size — which the network preset fixes and
-/// [`ChainSpec`] owns — is not carried on the value; the root is computed by
-/// dispatching on the list length to a size-specific SSZ-native helper below.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SyncCommittee {
     pubkeys: Vec<PubkeyBytes>,
@@ -244,6 +195,7 @@ struct CommitteeRoot32 {
     aggregate_pubkey: PubkeyBytes,
 }
 
+// TODO: Should any of these methods be scoped to pub(crate)?
 impl SyncCommittee {
     /// SSZ `hash_tree_root`, dispatched on the (spec-sized) committee length.
     pub(crate) fn hash_tree_root(&self) -> Root {
@@ -269,7 +221,6 @@ impl SyncCommittee {
         }
     }
 
-    /// The committee members (spec-sized: 32 or 512, no padding).
     pub fn pubkeys(&self) -> &[PubkeyBytes] {
         &self.pubkeys
     }
@@ -278,7 +229,7 @@ impl SyncCommittee {
         &self.aggregate_pubkey
     }
 
-    /// Number of committee members (spec-sized; no padding).
+    // TODO: Should this be here? can't users call pubkeys.len locally?
     pub fn len(&self) -> usize {
         self.pubkeys.len()
     }
@@ -317,6 +268,7 @@ impl SyncCommittee {
         Ok(out)
     }
 
+    // TODO: Should this method be more explicitly named?
     /// Build a spec-sized committee (32 or 512 keys) from raw pubkey bytes.
     ///
     /// Enforces the `{32, 512}` size invariant at construction, so the size
@@ -341,15 +293,9 @@ impl SyncCommittee {
     }
 }
 
-/// Sync aggregate data for light client updates.
-///
-/// `sync_committee_bits` is spec-sized (32 or 512, no padding) — one bit per
-/// committee member. The aggregate is never `hash_tree_root`'d, so it needs no
-/// SSZ derive; it's decoded off the wire and used for participation + BLS.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SyncAggregate {
     pub sync_committee_bits: Vec<bool>,
-    /// BLS aggregate signature
     pub sync_committee_signature: BLSSignature,
 }
 
@@ -368,13 +314,14 @@ impl SyncAggregate {
     }
 }
 
-/// [`LightClientHeader`]s are fork aware.
 #[derive(Debug, Clone, PartialEq)]
 pub struct LightClientUpdate {
     pub attested_header: LightClientHeader,
     pub finalized_header: Option<LightClientHeader>,
+    // TODO: Should this be wrapped in an option too?
     pub finality_branch: Vec<Root>,
     pub next_sync_committee: Option<SyncCommittee>,
+    // TODO: Should this be wrapped in an option too?
     pub next_sync_committee_branch: Vec<Root>,
     pub sync_aggregate: SyncAggregate,
     /// Should be attested_header.slot + 1
@@ -382,15 +329,6 @@ pub struct LightClientUpdate {
 }
 
 impl LightClientUpdate {
-    /// Decode an SSZ-encoded light client update for `fork`.
-    ///
-    /// `bytes` is raw SSZ as served by the beacon API (not snappy-framed).
-    /// `fork` selects the wire layout — obtain it from the beacon API's
-    /// `Eth-Consensus-Version` header, or the per-item fork-version prefix on
-    /// `/eth/v1/beacon/light_client/updates`. `sync_committee_size` is the
-    /// network preset's committee width (`32` minimal / `512` mainnet — use
-    /// [`ChainSpec::sync_committee_size`]); the wire layout depends on it but
-    /// the bytes don't carry it. (SSZ is not self-describing.)
     pub fn from_ssz(bytes: &[u8], fork: Fork, sync_committee_size: usize) -> Result<Self> {
         crate::types::ssz::decode_update(bytes, fork, sync_committee_size)
     }
@@ -451,35 +389,15 @@ impl LightClientUpdate {
     }
 }
 
-/// Bootstrap data for initializing a light client.
-///
-/// This is the trusted anchor from which light client sync begins. It contains:
-/// - A trusted light client header (fork-aware, typically a finalized checkpoint)
-/// - The sync committee active at that header's slot
-/// - A merkle proof that the sync committee is embedded in the header's state root
-/// - The genesis validators root for the chain (used in signature domain computation)
-///
-/// Corresponds to the `LightClientBootstrap` object in the Ethereum consensus specs.
 #[derive(Debug, Clone, PartialEq)]
 pub struct LightClientBootstrap {
-    /// The trusted header (fork-aware).
     pub header: LightClientHeader,
-    /// The current sync committee at the header's slot.
     pub current_sync_committee: SyncCommittee,
-    /// Merkle branch proving `current_sync_committee` is in `header.state_root`.
-    /// Length depends on the fork (Altair: 5 nodes).
     pub current_sync_committee_branch: Vec<Root>,
-    /// Genesis validators root for the chain (network identifier for domain computation).
     pub genesis_validators_root: Root,
 }
 
 impl LightClientBootstrap {
-    /// Decode an SSZ-encoded light client bootstrap for `fork`.
-    ///
-    /// `bytes` is raw SSZ as served by the beacon API (not snappy-framed).
-    /// `fork` and `sync_committee_size` select the wire layout (see
-    /// [`LightClientUpdate::from_ssz`]). `genesis_validators_root` is supplied
-    /// out-of-band (from beacon genesis); it is not part of the bootstrap message.
     pub fn from_ssz(
         bytes: &[u8],
         fork: Fork,
@@ -517,15 +435,10 @@ impl LightClientBootstrap {
 /// Headers are fork-aware [`LightClientHeader`] values.
 #[derive(Debug, Clone)]
 pub(crate) struct LightClientStore {
-    /// Best finalized header we've seen (fork-aware).
     pub finalized_header: LightClientHeader,
-    /// Current sync committee
     pub current_sync_committee: SyncCommittee,
-    /// Next sync committee (if known)
     pub next_sync_committee: Option<SyncCommittee>,
-    /// Optimistic header (may not be finalized, fork-aware).
     pub optimistic_header: LightClientHeader,
-    /// Genesis validators root (chain identity for signature domains)
     pub genesis_validators_root: Root,
 }
 

--- a/src/types/consensus.rs
+++ b/src/types/consensus.rs
@@ -99,7 +99,6 @@ pub struct ExecutionPayloadHeaderCapella {
     pub withdrawals_root: Root,
 }
 
-// TODO: Does this method make sense?
 impl ExecutionPayloadHeaderCapella {
     /// SSZ `hash_tree_root` as a [`Root`] — thin wrapper over the derived
     /// [`TreeHash`] impl (the field-by-field merkleization is now generated).
@@ -135,7 +134,6 @@ pub struct ExecutionPayloadHeaderDeneb {
     pub excess_blob_gas: u64,
 }
 
-// TODO: Does this method make sense?
 impl ExecutionPayloadHeaderDeneb {
     /// SSZ `hash_tree_root` as a [`Root`] — thin wrapper over the derived
     /// [`TreeHash`] impl.
@@ -145,13 +143,11 @@ impl ExecutionPayloadHeaderDeneb {
 }
 
 impl LightClientHeader {
-    // TODO: Does this method make sense?
     /// Wrap a `BeaconBlockHeader` as an Altair-era header.
     pub(crate) fn altair(beacon: BeaconBlockHeader) -> Self {
         Self::Altair(AltairLightClientHeader { beacon })
     }
 
-    // TODO: Should we delete?
     /// Wrap a `BeaconBlockHeader` as a Bellatrix-era header.
     pub(crate) fn bellatrix(beacon: BeaconBlockHeader) -> Self {
         Self::Bellatrix(BellatrixLightClientHeader { beacon })
@@ -195,7 +191,6 @@ struct CommitteeRoot32 {
     aggregate_pubkey: PubkeyBytes,
 }
 
-// TODO: Should any of these methods be scoped to pub(crate)?
 impl SyncCommittee {
     /// SSZ `hash_tree_root`, dispatched on the (spec-sized) committee length.
     pub(crate) fn hash_tree_root(&self) -> Root {
@@ -229,13 +224,8 @@ impl SyncCommittee {
         &self.aggregate_pubkey
     }
 
-    // TODO: Should this be here? can't users call pubkeys.len locally?
-    pub fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         self.pubkeys.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.pubkeys.is_empty()
     }
 
     /// 2/3 supermajority over the spec-sized committee.
@@ -268,7 +258,6 @@ impl SyncCommittee {
         Ok(out)
     }
 
-    // TODO: Should this method be more explicitly named?
     /// Build a spec-sized committee (32 or 512 keys) from raw pubkey bytes.
     ///
     /// Enforces the `{32, 512}` size invariant at construction, so the size

--- a/src/types/consensus.rs
+++ b/src/types/consensus.rs
@@ -317,15 +317,27 @@ impl SyncAggregate {
 #[derive(Debug, Clone, PartialEq)]
 pub struct LightClientUpdate {
     pub attested_header: LightClientHeader,
-    pub finalized_header: Option<LightClientHeader>,
-    // TODO: Should this be wrapped in an option too?
-    pub finality_branch: Vec<Root>,
-    pub next_sync_committee: Option<SyncCommittee>,
-    // TODO: Should this be wrapped in an option too?
-    pub next_sync_committee_branch: Vec<Root>,
+    /// The finalized header and its finality branch — present together or not at all.
+    pub finalized: Option<FinalityUpdate>,
+    /// The next sync committee and its inclusion branch — present together or not at all.
+    pub next_sync_committee: Option<SyncCommitteeUpdate>,
     pub sync_aggregate: SyncAggregate,
     /// Should be attested_header.slot + 1
     pub signature_slot: Slot,
+}
+
+/// A finalized header paired with the Merkle branch proving it in the attested state.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FinalityUpdate {
+    pub header: LightClientHeader,
+    pub branch: Vec<Root>,
+}
+
+/// A next sync committee paired with the Merkle branch proving it in the attested state.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SyncCommitteeUpdate {
+    pub committee: SyncCommittee,
+    pub branch: Vec<Root>,
 }
 
 impl LightClientUpdate {
@@ -342,23 +354,16 @@ impl LightClientUpdate {
     ) -> Self {
         Self {
             attested_header: LightClientHeader::altair(attested_header),
-            finalized_header: None,
-            finality_branch: Vec::new(),
+            finalized: None,
             next_sync_committee: None,
-            next_sync_committee_branch: Vec::new(),
             sync_aggregate,
             signature_slot,
         }
     }
 
     #[cfg(test)]
-    pub fn with_next_sync_committee(
-        mut self,
-        next_sync_committee: SyncCommittee,
-        next_sync_committee_branch: Vec<Root>,
-    ) -> Self {
-        self.next_sync_committee = Some(next_sync_committee);
-        self.next_sync_committee_branch = next_sync_committee_branch;
+    pub fn with_next_sync_committee(mut self, committee: SyncCommittee, branch: Vec<Root>) -> Self {
+        self.next_sync_committee = Some(SyncCommitteeUpdate { committee, branch });
         self
     }
 
@@ -523,7 +528,7 @@ mod tests {
 
         let sync_committee = create_test_sync_committee();
         assert!(update.validate_basic(&sync_committee).is_ok());
-        assert!(update.finalized_header.is_none());
+        assert!(update.finalized.is_none());
         assert!(!update.has_sync_committee_update());
     }
 

--- a/src/types/consensus.rs
+++ b/src/types/consensus.rs
@@ -361,10 +361,6 @@ impl SyncAggregate {
         }
     }
 
-    pub(crate) fn participation_count(&self) -> usize {
-        self.sync_committee_bits.iter().filter(|&&bit| bit).count()
-    }
-
     /// Check if sync aggregate has supermajority participation
     /// Uses actual committee size from the provided sync committee
     pub(crate) fn has_supermajority(&self, sync_committee: &SyncCommittee) -> bool {
@@ -531,11 +527,6 @@ pub(crate) struct LightClientStore {
     pub optimistic_header: LightClientHeader,
     /// Genesis validators root (chain identity for signature domains)
     pub genesis_validators_root: Root,
-    /// Previous max active participants (used by force_update - not yet implemented)
-    #[allow(dead_code)]
-    pub previous_max_active_participants: u64,
-    /// Current max active participants
-    pub current_max_active_participants: u64,
 }
 
 impl LightClientStore {
@@ -550,8 +541,6 @@ impl LightClientStore {
             current_sync_committee,
             next_sync_committee: None,
             genesis_validators_root,
-            previous_max_active_participants: 0,
-            current_max_active_participants: 0,
         }
     }
 
@@ -560,20 +549,6 @@ impl LightClientStore {
     /// This is the canonical "store period" per consensus-specs.
     pub(crate) fn finalized_sync_committee_period(&self, spec: &ChainSpec) -> u64 {
         spec.slot_to_sync_committee_period(self.finalized_header.slot())
-    }
-
-    // The following methods are reserved for future force_update implementation
-
-    /// Get the next sync committee period.
-    #[allow(dead_code)]
-    pub fn next_period(&self, spec: &ChainSpec) -> u64 {
-        self.finalized_sync_committee_period(spec) + 1
-    }
-
-    /// Check if we should update the sync committee for the given period.
-    #[allow(dead_code)]
-    pub fn should_update_sync_committee(&self, spec: &ChainSpec, period: u64) -> bool {
-        period == self.next_period(spec) && self.next_sync_committee.is_some()
     }
 }
 
@@ -653,7 +628,6 @@ mod tests {
         );
         // slot 1000 -> epoch 31 -> period 0
         assert_eq!(store.finalized_sync_committee_period(&spec), 0);
-        assert_eq!(store.next_period(&spec), 1);
         assert_eq!(store.genesis_validators_root, genesis_validators_root);
     }
 }

--- a/src/types/consensus.rs
+++ b/src/types/consensus.rs
@@ -37,7 +37,7 @@ impl BeaconBlockHeader {
     }
 
     /// Compute the hash tree root of the beacon block header using TreeHash
-    pub fn hash_tree_root(&self) -> Result<Root> {
+    pub(crate) fn hash_tree_root(&self) -> Result<Root> {
         let hash256 = TreeHash::tree_hash_root(self);
         let mut result = [0u8; 32];
         result.copy_from_slice(hash256.as_bytes());
@@ -128,7 +128,7 @@ pub struct ExecutionPayloadHeaderCapella {
 impl ExecutionPayloadHeaderCapella {
     /// SSZ `hash_tree_root` as a [`Root`] — thin wrapper over the derived
     /// [`TreeHash`] impl (the field-by-field merkleization is now generated).
-    pub fn hash_tree_root(&self) -> Root {
+    pub(crate) fn hash_tree_root(&self) -> Root {
         self.tree_hash_root().0
     }
 }
@@ -175,49 +175,20 @@ pub struct ExecutionPayloadHeaderDeneb {
 impl ExecutionPayloadHeaderDeneb {
     /// SSZ `hash_tree_root` as a [`Root`] — thin wrapper over the derived
     /// [`TreeHash`] impl.
-    pub fn hash_tree_root(&self) -> Root {
+    pub(crate) fn hash_tree_root(&self) -> Root {
         self.tree_hash_root().0
     }
 }
 
 impl LightClientHeader {
     /// Wrap a `BeaconBlockHeader` as an Altair-era header.
-    pub fn altair(beacon: BeaconBlockHeader) -> Self {
+    pub(crate) fn altair(beacon: BeaconBlockHeader) -> Self {
         Self::Altair(AltairLightClientHeader { beacon })
     }
 
     /// Wrap a `BeaconBlockHeader` as a Bellatrix-era header.
-    #[allow(dead_code)]
-    pub fn bellatrix(beacon: BeaconBlockHeader) -> Self {
+    pub(crate) fn bellatrix(beacon: BeaconBlockHeader) -> Self {
         Self::Bellatrix(BellatrixLightClientHeader { beacon })
-    }
-
-    /// Construct a Capella header with execution payload and inclusion proof.
-    #[allow(dead_code)]
-    pub fn capella(
-        beacon: BeaconBlockHeader,
-        execution: ExecutionPayloadHeaderCapella,
-        execution_branch: [Root; 4],
-    ) -> Self {
-        Self::Capella(CapellaLightClientHeader {
-            beacon,
-            execution,
-            execution_branch: FixedVector::new(execution_branch.to_vec()).expect("branch is 4"),
-        })
-    }
-
-    /// Construct a Deneb header with execution payload and inclusion proof.
-    #[allow(dead_code)]
-    pub fn deneb(
-        beacon: BeaconBlockHeader,
-        execution: ExecutionPayloadHeaderDeneb,
-        execution_branch: [Root; 4],
-    ) -> Self {
-        Self::Deneb(DenebLightClientHeader {
-            beacon,
-            execution,
-            execution_branch: FixedVector::new(execution_branch.to_vec()).expect("branch is 4"),
-        })
     }
 
     /// The inner `BeaconBlockHeader` (available for all forks).
@@ -238,25 +209,6 @@ impl LightClientHeader {
     /// The header's state root.
     pub fn state_root(&self) -> &Root {
         &self.beacon().state_root
-    }
-
-    /// Compute the hash tree root of this header.
-    ///
-    /// - Altair/Bellatrix: `hash_tree_root(beacon)` (1-field container).
-    /// - Capella/Deneb: `hash_tree_root({beacon, execution, execution_branch})`
-    ///   (3-field container). The container shape is identical; only the inner
-    ///   `execution.hash_tree_root()` differs across forks.
-    pub fn hash_tree_root(&self) -> Result<Root> {
-        match self {
-            // Altair/Bellatrix have no LightClientHeader container (it arrived in
-            // Capella); the header root is the beacon root.
-            Self::Altair(h) => h.beacon.hash_tree_root(),
-            Self::Bellatrix(h) => h.beacon.hash_tree_root(),
-            // Capella/Deneb are 3-field containers `{beacon, execution,
-            // execution_branch}` — the derived TreeHash does the merkleization.
-            Self::Capella(h) => Ok(h.tree_hash_root().0),
-            Self::Deneb(h) => Ok(h.tree_hash_root().0),
-        }
     }
 }
 
@@ -294,7 +246,7 @@ struct CommitteeRoot32 {
 
 impl SyncCommittee {
     /// SSZ `hash_tree_root`, dispatched on the (spec-sized) committee length.
-    pub fn hash_tree_root(&self) -> Root {
+    pub(crate) fn hash_tree_root(&self) -> Root {
         let agg = self.aggregate_pubkey.clone();
         match self.pubkeys.len() {
             512 => {
@@ -336,7 +288,7 @@ impl SyncCommittee {
     }
 
     /// 2/3 supermajority over the spec-sized committee.
-    pub fn has_supermajority_participation(&self, participation_bits: &[bool]) -> bool {
+    pub(crate) fn has_supermajority_participation(&self, participation_bits: &[bool]) -> bool {
         if participation_bits.len() != self.len() {
             return false;
         }
@@ -345,7 +297,10 @@ impl SyncCommittee {
     }
 
     /// Bit-selected participating pubkeys as raw 48-byte keys (for BLS).
-    pub fn participating_pubkeys(&self, participation_bits: &[bool]) -> Result<Vec<BLSPublicKey>> {
+    pub(crate) fn participating_pubkeys(
+        &self,
+        participation_bits: &[bool],
+    ) -> Result<Vec<BLSPublicKey>> {
         if participation_bits.len() != self.len() {
             return Err(Error::InvalidInput(
                 "Participation bits length mismatch".to_string(),
@@ -406,13 +361,13 @@ impl SyncAggregate {
         }
     }
 
-    pub fn participation_count(&self) -> usize {
+    pub(crate) fn participation_count(&self) -> usize {
         self.sync_committee_bits.iter().filter(|&&bit| bit).count()
     }
 
     /// Check if sync aggregate has supermajority participation
     /// Uses actual committee size from the provided sync committee
-    pub fn has_supermajority(&self, sync_committee: &SyncCommittee) -> bool {
+    pub(crate) fn has_supermajority(&self, sync_committee: &SyncCommittee) -> bool {
         sync_committee.has_supermajority_participation(self.sync_committee_bits.as_ref())
     }
 }
@@ -444,7 +399,8 @@ impl LightClientUpdate {
         crate::types::ssz::decode_update(bytes, fork, sync_committee_size)
     }
 
-    /// Create a new update wrapping a `BeaconBlockHeader` as Altair.
+    /// Test builder: an Altair-wrapped update with no finality / next committee.
+    #[cfg(test)]
     pub fn new(
         attested_header: BeaconBlockHeader,
         sync_aggregate: SyncAggregate,
@@ -461,16 +417,7 @@ impl LightClientUpdate {
         }
     }
 
-    pub fn with_finalized_header(
-        mut self,
-        finalized_header: BeaconBlockHeader,
-        finality_branch: Vec<Root>,
-    ) -> Self {
-        self.finalized_header = Some(LightClientHeader::altair(finalized_header));
-        self.finality_branch = finality_branch;
-        self
-    }
-
+    #[cfg(test)]
     pub fn with_next_sync_committee(
         mut self,
         next_sync_committee: SyncCommittee,
@@ -486,7 +433,7 @@ impl LightClientUpdate {
     /// Enforces:
     /// - `signature_slot > attested_header.slot`
     /// - supermajority participation
-    pub fn validate_basic(&self, sync_committee: &SyncCommittee) -> Result<()> {
+    pub(crate) fn validate_basic(&self, sync_committee: &SyncCommittee) -> Result<()> {
         if self.signature_slot <= self.attested_header.slot() {
             return Err(Error::InvalidInput(
                 "Signature slot must be after attested header slot".to_string(),
@@ -503,23 +450,8 @@ impl LightClientUpdate {
     }
 
     /// Check if this update contains sync committee changes
-    pub fn has_sync_committee_update(&self) -> bool {
+    pub(crate) fn has_sync_committee_update(&self) -> bool {
         self.next_sync_committee.is_some()
-    }
-
-    /// Check if this update contains finality information
-    pub fn has_finality_update(&self) -> bool {
-        self.finalized_header.is_some()
-    }
-
-    /// Get the period of the attested header.
-    pub fn attested_period(&self, spec: &ChainSpec) -> u64 {
-        spec.slot_to_sync_committee_period(self.attested_header.slot())
-    }
-
-    /// Get the period of the signature slot.
-    pub fn signature_period(&self, spec: &ChainSpec) -> u64 {
-        spec.slot_to_sync_committee_period(self.signature_slot)
     }
 }
 
@@ -566,23 +498,8 @@ impl LightClientBootstrap {
         )
     }
 
-    /// Create a new bootstrap package from a `BeaconBlockHeader` (convenience, wraps as Altair).
-    pub fn new(
-        header: BeaconBlockHeader,
-        current_sync_committee: SyncCommittee,
-        current_sync_committee_branch: Vec<Root>,
-        genesis_validators_root: Root,
-    ) -> Self {
-        Self::from_header(
-            LightClientHeader::altair(header),
-            current_sync_committee,
-            current_sync_committee_branch,
-            genesis_validators_root,
-        )
-    }
-
-    /// Create a new bootstrap package from a fork-aware [`LightClientHeader`].
-    pub fn from_header(
+    /// Assemble a bootstrap from a fork-aware [`LightClientHeader`] (used by decode).
+    pub(crate) fn from_header(
         header: LightClientHeader,
         current_sync_committee: SyncCommittee,
         current_sync_committee_branch: Vec<Root>,
@@ -718,7 +635,7 @@ mod tests {
 
         let sync_committee = create_test_sync_committee();
         assert!(update.validate_basic(&sync_committee).is_ok());
-        assert!(!update.has_finality_update());
+        assert!(update.finalized_header.is_none());
         assert!(!update.has_sync_committee_update());
     }
 

--- a/src/types/ssz.rs
+++ b/src/types/ssz.rs
@@ -13,8 +13,8 @@
 
 use crate::config::Fork;
 use crate::types::consensus::{
-    BeaconBlockHeader, CapellaLightClientHeader, LightClientBootstrap, LightClientHeader,
-    LightClientUpdate, SyncAggregate, SyncCommittee,
+    BeaconBlockHeader, CapellaLightClientHeader, FinalityUpdate, LightClientBootstrap,
+    LightClientHeader, LightClientUpdate, SyncAggregate, SyncCommittee, SyncCommitteeUpdate,
 };
 use crate::types::primitives::Root;
 use ssz::Decode as _;
@@ -127,7 +127,6 @@ fn assemble_update(
     sync_aggregate: SyncAggregate,
     signature_slot: u64,
 ) -> LightClientUpdate {
-    let has_finality = finalized_header.is_some();
     let has_sync_committee = !sync_committee
         .pubkeys()
         .iter()
@@ -135,18 +134,14 @@ fn assemble_update(
 
     LightClientUpdate {
         attested_header,
-        finalized_header,
-        finality_branch: if has_finality {
-            finality_branch
-        } else {
-            Vec::new()
-        },
-        next_sync_committee: has_sync_committee.then_some(sync_committee),
-        next_sync_committee_branch: if has_sync_committee {
-            next_sync_committee_branch
-        } else {
-            Vec::new()
-        },
+        finalized: finalized_header.map(|header| FinalityUpdate {
+            header,
+            branch: finality_branch,
+        }),
+        next_sync_committee: has_sync_committee.then_some(SyncCommitteeUpdate {
+            committee: sync_committee,
+            branch: next_sync_committee_branch,
+        }),
         sync_aggregate,
         signature_slot,
     }


### PR DESCRIPTION
Audit pass over `types/consensus.rs` (the consensus data-type module). Behavior-preserving; full suite green throughout.

## Commits
1. **Trim public surface** (−108) — cut `pub` down to the real external API (the re-exported types, `from_ssz`, `BeaconBlockHeader` fields, no-arg readers). Removed dead constructors/methods, gated the test-only builders `#[cfg(test)]`, demoted verification/compute helpers to `pub(crate)`. Public `fn` count ~halved.
2. **Remove force_update scaffolding** (−32, #56) — dead store fields/methods + participation tracking; returns when force_update is actually implemented.
3. **Comment sweep** — strip verbose doc comments, leaving open-question TODOs (recovered + reconciled from an editor buffer that had diverged from the trim).
4. **Pair each header/committee with its branch behind one `Option`** — `FinalityUpdate { header, branch }` / `SyncCommitteeUpdate { committee, branch }` make invalid states (header without proof, or vice-versa) unrepresentable. Decoder builds them; processor/learn-next read from them and no longer assume consistency. Wire format unchanged.
5. **Resolve/clear TODOs** — answer and remove all 7; `consensus.rs` is now TODO-free.

## Verification
- Full suite green: 54 lib + 3 public-API integration + doc-tests.
- `cargo clippy --all-targets --features test-utils -D warnings` clean.

The remaining agenda item — **decomposition** (splitting the 4 type-groups into a module tree) — is deferred to its own branch/decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)