### PR TITLE
docs: doc audit — INVARIANTS into CLAUDE.md, package metadata, README restructure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,10 +12,19 @@ The goal is to verify Ethereum consensus-layer light client bootstraps and updat
 - Preserve explicit fork-aware design.
 - Do not collapse fork-specific types into vague generic structs unless explicitly justified.
 - Do not silently weaken verification logic to make tests pass.
-- Treat SSZ `hash_tree_root`, Merkle generalized indices, fork versions, signing domains, and sync committee validation as correctness-critical.
+- Treat merkleization logic, fork versions, signing domains, and sync committee validation as correctness-critical.
 - Prefer official Ethereum consensus spec tests and fixtures whenever possible.
 - Before editing code, inspect the relevant architecture and summarize the proposed change.
 - After editing code, run targeted tests and explain what passed, what failed, and what remains untested.
+
+## Invariants 
+
+1. protocol/spec conformance is the highest priority
+2. fork behavior must be spec-driven, not hardcoded ad hoc
+3. avoid duplicate mutable sources of truth
+4. validation before state mutation
+5. public API should expose stable protocol-level concepts, not convenience internals
+6. regression-prone bugs should get targeted tests
 
 ## Architecture assumptions
 
@@ -27,7 +36,7 @@ Important public API / processing anchors:
 - `ChainSpec` models fork schedule and fork versions.
 - Light client data structures are fork-aware.
 - Capella and later headers include execution payload header data plus an execution branch.
-- Verification should use the beacon header root where the Ethereum spec expects the beacon root, not the full light client header root.
+- Verification should use the beacon header root where the protocol expects it, not the full light client header root.
 
 ## Development direction
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,32 +7,24 @@ description = "Verification-only Ethereum consensus-layer light client"
 license = "MIT OR Apache-2.0"
 # repository = "https://github.com/yourusername/eth-light-client"
 keywords = ["ethereum", "blockchain", "light-client", "consensus"]
-categories = ["cryptography", "network-programming"]
+categories = ["ethereum", "blockchain", "cryptography", "network-programming"]
 resolver = "2"
 
 [dependencies]
-# Serialization
 serde = { version = "1.0", features = ["derive"] }
 hex = "0.4"
-
-# Cryptography
-blst = "0.3.10"  # BLS signatures for beacon chain
-
-# SSZ and Tree Hashing - Production-grade libraries used by Lighthouse
-ethereum_ssz = "0.5"        # SSZ encoding/decoding
-ethereum_ssz_derive = "0.5" # SSZ derive macros
-tree_hash = "0.5"           # TreeHash trait and merkle root computation
-tree_hash_derive = "0.5"    # Derive macros for TreeHash
-ethereum_hashing = "1.0.0-beta.2" # SHA256 (hash32_concat) for merkle branch steps
-
-# Error handling
+blst = "0.3.10" 
+ethereum_ssz = "0.5" 
+ethereum_ssz_derive = "0.5" 
+tree_hash = "0.5"
+tree_hash_derive = "0.5" 
+ethereum_hashing = "1.0.0-beta.2" 
 thiserror = "1.0"
 ssz_types = "0.5"
 ethereum-types = "0.14"
 
 [features]
 default = []
-# Expose test utilities for integration tests and downstream testing.
 # Not part of the stable API - may change without notice.
 test-utils = ["dep:serde_yaml", "dep:snap"]
 
@@ -46,9 +38,9 @@ optional = true
 
 # Testing
 [dev-dependencies]
-serde_yaml = "0.9"  # For parsing test metadata (meta.yaml, steps.yaml)
-walkdir = "2.4"     # For recursively finding BLS test cases
-snap = "1.1"        # For decompressing .ssz_snappy files
+serde_yaml = "0.9"
+walkdir = "2.4"
+snap = "1.1"
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "Verification-only Ethereum consensus-layer light client"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/EchoAlice/eth-light-client"
 keywords = ["ethereum", "blockchain", "light-client", "consensus"]
-categories = ["ethereum", "blockchain", "cryptography", "network-programming"]
+categories = ["cryptography", "network-programming"]
 resolver = "2"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,9 @@
 name = "eth-light-client"
 version = "0.1.0"
 edition = "2021"
-# authors = ["Echo echoalice0@gmail.com"]
 description = "Verification-only Ethereum consensus-layer light client"
 license = "MIT OR Apache-2.0"
-# repository = "https://github.com/yourusername/eth-light-client"
+repository = "https://github.com/EchoAlice/eth-light-client"
 keywords = ["ethereum", "blockchain", "light-client", "consensus"]
 categories = ["ethereum", "blockchain", "cryptography", "network-programming"]
 resolver = "2"
@@ -25,7 +24,6 @@ ethereum-types = "0.14"
 
 [features]
 default = []
-# Not part of the stable API - may change without notice.
 test-utils = ["dep:serde_yaml", "dep:snap"]
 
 [dependencies.serde_yaml]

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -1,8 +1,0 @@
-## High-Level Design Rules for Agents
-
-1. protocol/spec conformance is the highest priority
-2. fork behavior must be spec-driven, not hardcoded ad hoc
-3. avoid duplicate mutable sources of truth
-4. validation before state mutation
-5. public API should expose stable protocol-level concepts, not convenience internals
-6. regression-prone bugs should get targeted tests

--- a/README.md
+++ b/README.md
@@ -1,23 +1,20 @@
 # Ethereum Light Client
 
-<br>
-
 ### Security Disclaimer
-Experimental.  Do not use for Ethereum mainnet security-critical decisions!
+Experimental.  Do not use for security-critical decisions
 
-<br>
 
-## Summary
+# Summary
 **This is a Rust library that implements Ethereum’s consensus-layer light client sync protocol**.  It exposes the verification logic required to independently verify the legitimacy of the latest (i) finalized and (ii) optimistic beacon block headers, *without having to run a full node*.
 
 For a module-by-module map of the crate, see [`src/README.md`](src/README.md); for the verification data flow and correctness invariants, see [`src/consensus/README.md`](src/consensus/README.md).
 
 ### Background
-Independently verified information within the Ethereum blockchain used to be something only people running full nodes had access to. Individuals that didn't have the computational resources to run their own node had to rely on others for blockchain information.  And they had to **trust** that the responding party wasn't lying to them.
+Independently verified information within the Ethereum blockchain used to be something only people running full nodes had access to. Individuals that didn't have the computational resources (or know-how) to run their own node had to rely on others to provide the blockchain's information.  And they had to **trust** that the responding party wasn't lying to them.
 
-But since Ethereum began supporting the [light client sync protocol](https://ethereum.github.io/consensus-specs/specs/altair/light-client/sync-protocol/), the "truth of the chain" became accessible to a much larger class of applications and devices *through light clients*.
+But since Ethereum began supporting the [light client sync protocol](https://ethereum.github.io/consensus-specs/specs/altair/light-client/sync-protocol/), independent verification of Ethereum's information became accessible to a much larger class of applications and devices.
 
-**Who Can Benefit?**
+**Who Can Benefit From Light Clients?**
 - Wallets: “Is this transaction actually finalized?”
 - Bridges / relays: “Has this event that happened on Ethereum finalized?” (safety-critical)
 - Browsers/extensions: “Show accurate chain status without trusting an RPC.”
@@ -39,17 +36,17 @@ From Capella onward, supported light client headers also include authenticated e
 
 However, validating information against those roots is the user's responsibility.
 
-## Usage
+## Trust Model
 - Users must provide a `LightClientBootstrap` from a **trusted** source.  This anchors the light client to a trusted finalized beacon block.
 - Users then fetch `LightClientUpdate`s from any source (beacon node API, relay, etc).  The light client verifies each update locally before advancing its finalized and/or optimistic view of the chain.
 
-The finalized header is the client’s safest verified view of the chain. The optimistic header is the client’s freshest verified view, but it may advance before finality.
-
-**Trust Model:**
-- **Safety** follows from correct verification, given the user provides a legitimate bootstrap.
-- **Liveness** depends on the user's update source (and will improve further once `force_update` is implemented).
+The finalized header is the client’s safest verified view of the chain. The optimistic header is the client’s freshest verified view, but may advance before finality. 
 
 See [`src/consensus/README.md`](src/consensus/README.md) for the verification data flow and correctness invariants.
+
+<br/>
+
+# Usage
 
 **Installation**
 Add this to your `Cargo.toml`:
@@ -93,7 +90,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 ```
-**Note:** This example omits the Beacon API fetching (the `/* fetch */` placeholders); the library begins at the SSZ-decode and verification boundary.
+**Note:** This library begins at the SSZ-decode and verification boundary.
 
 **API Notes:**
 - Injectable time is available: If you want to supply your own notion of time (tests, embedded devices, custom clocks), use `process_update_at_slot(update, current_slot)`
@@ -109,14 +106,14 @@ For local testnets or devnets, use `ChainSpecConfig` with `ChainSpec::try_from_c
   - `32` for the minimal preset
 - SSZ tree layouts and generalized indices are not fully generic inputs; proof paths are implemented explicitly for each supported fork
 
-### SSZ
+## SSZ 
 The crate uses a single SSZ implementation — the Sigma Prime / Lighthouse stack: **`ethereum_ssz`** (encode/decode) + **`ssz_types`** (length-bounded collections: `FixedVector`, `VariableList`, `BitVector`) + **`tree_hash`** (`hash_tree_root`). Public types carry their SSZ traits by deriving them (`#[derive(Encode, Decode, TreeHash)]`), so there is no hand-written merkleization.
 
 The one piece of custom SSZ code is the wire-decode adapter in `src/types/ssz.rs`: it decodes fork-specific wire layouts and adapts them to the library's public types (fork-enum headers, `Option` fields, the spec-sized sync committee).  The wire adapter leverages `ethereum_ssz` where it can.
 
 ## Testing
 This library is end-to-end tested against official Ethereum Consensus minimal-preset light client spec tests for Altair, Bellatrix, and Capella hardforks.  Tests exercise the full verification flow through the public API:
-`LightClient::new` (bootstrap verification) and `process_update` (update verification).
+`LightClient::new` (bootstrap verification) and `process_update` (update verification).  End-to-end coverage against mainnet parameters (512-member committees) is still pending.
 
 ```bash
 # Unit + integration tests
@@ -146,9 +143,6 @@ BLS signature verification is covered by official Ethereum consensus spec test v
 3. Add serialization support (e.g. serde feature) so consumers can persist/restore LightClientStore
 4. Implement `force_update` for all forks
 5. Add a small "HTTP updater" example crate (separate from core; keep library verification-only)
-
-## Credits
-This library is being created with the help of Claude Code (Opus 4.6) and ChatGPT (5.3).
 
 ## License
 MIT OR Apache-2.0


### PR DESCRIPTION
First pass of a documentation audit (more to come on a follow-up branch).

## Changes
- **`INVARIANTS.md` → `CLAUDE.md`**: folded the six agent design-rule invariants into a new "Invariants" section; deleted `INVARIANTS.md` (single source).
- **`Cargo.toml` metadata**: enabled `repository` with the real URL, dropped the legacy `authors` field, removed invalid crates.io category slugs (`ethereum`/`blockchain` — they'd fail `cargo publish`; already in `keywords`), trimmed comments.
- **`README.md`**: split a dedicated "Trust Model" section (finalized vs optimistic view + trusted-bootstrap anchoring) out of Usage; reframed "Who Can Benefit" around light clients generally; noted mainnet-parameter test coverage is still pending; removed in-progress TODO/scaffolding and the stale Credits section.

No code changes. Deeper README passes (esp. `src/consensus/README.md`, and a safety/liveness section) will follow on a separate branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)