### PR TITLE
refactor: make ssz.rs decode-only (drop unused Encode)

### DIFF
--- a/src/types/ssz.rs
+++ b/src/types/ssz.rs
@@ -19,11 +19,11 @@ use crate::types::consensus::{
 };
 use crate::types::primitives::Root;
 use ssz::Decode as _;
-use ssz_derive::{Decode, Encode};
+use ssz_derive::Decode;
 use ssz_types::typenum::{Unsigned, U32, U48, U5, U512, U6, U96};
 use ssz_types::{BitVector, FixedVector};
 
-#[derive(Encode, Decode)]
+#[derive(Decode)]
 struct RawSyncCommittee<N: Unsigned> {
     pubkeys: FixedVector<FixedVector<u8, U48>, N>,
     aggregate_pubkey: FixedVector<u8, U48>,
@@ -48,7 +48,7 @@ impl<N: Unsigned> RawSyncCommittee<N> {
     }
 }
 
-#[derive(Encode, Decode)]
+#[derive(Decode)]
 struct RawSyncAggregate<N: Unsigned> {
     sync_committee_bits: BitVector<N>,
     sync_committee_signature: FixedVector<u8, U96>,
@@ -67,7 +67,7 @@ impl<N: Unsigned> RawSyncAggregate<N> {
 
 // Beacon-only (Altair/Bellatrix): the header is a `BeaconBlockHeader` on the wire
 // (the 1-field LightClientHeader wrapper is serialization-transparent).
-#[derive(Encode, Decode)]
+#[derive(Decode)]
 struct RawLightClientUpdate<N: Unsigned> {
     attested_header: BeaconBlockHeader,
     next_sync_committee: RawSyncCommittee<N>,
@@ -78,7 +78,7 @@ struct RawLightClientUpdate<N: Unsigned> {
     signature_slot: u64,
 }
 
-#[derive(Encode, Decode)]
+#[derive(Decode)]
 struct RawLightClientBootstrap<N: Unsigned> {
     header: BeaconBlockHeader,
     current_sync_committee: RawSyncCommittee<N>,
@@ -86,7 +86,7 @@ struct RawLightClientBootstrap<N: Unsigned> {
 }
 
 // Capella+: the header is the public `CapellaLightClientHeader` container.
-#[derive(Encode, Decode)]
+#[derive(Decode)]
 struct RawCapellaLightClientUpdate<N: Unsigned> {
     attested_header: CapellaLightClientHeader,
     next_sync_committee: RawSyncCommittee<N>,
@@ -97,7 +97,7 @@ struct RawCapellaLightClientUpdate<N: Unsigned> {
     signature_slot: u64,
 }
 
-#[derive(Encode, Decode)]
+#[derive(Decode)]
 struct RawCapellaLightClientBootstrap<N: Unsigned> {
     header: CapellaLightClientHeader,
     current_sync_committee: RawSyncCommittee<N>,
@@ -106,7 +106,7 @@ struct RawCapellaLightClientBootstrap<N: Unsigned> {
 
 // Deneb+: identical wire shape to Capella except the header is a
 // `DenebLightClientHeader` (its execution payload carries the two EIP-4844 fields).
-#[derive(Encode, Decode)]
+#[derive(Decode)]
 struct RawDenebLightClientUpdate<N: Unsigned> {
     attested_header: DenebLightClientHeader,
     next_sync_committee: RawSyncCommittee<N>,
@@ -117,7 +117,7 @@ struct RawDenebLightClientUpdate<N: Unsigned> {
     signature_slot: u64,
 }
 
-#[derive(Encode, Decode)]
+#[derive(Decode)]
 struct RawDenebLightClientBootstrap<N: Unsigned> {
     header: DenebLightClientHeader,
     current_sync_committee: RawSyncCommittee<N>,
@@ -352,29 +352,6 @@ fn unsupported(fork: Fork) -> crate::error::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ssz::Encode;
-
-    // No official mainnet fixtures exist, so the 512-committee decode path is
-    // validated by an SSZ round-trip: encode a mainnet-sized bootstrap, decode
-    // it back through the public `from_ssz`, and check the committee width.
-    #[test]
-    fn decodes_mainnet_sized_512_committee() {
-        let committee = RawSyncCommittee::<U512> {
-            pubkeys: FixedVector::new(vec![FixedVector::new(vec![7u8; 48]).unwrap(); 512]).unwrap(),
-            aggregate_pubkey: FixedVector::new(vec![9u8; 48]).unwrap(),
-        };
-        let raw = RawLightClientBootstrap::<U512> {
-            header: BeaconBlockHeader::new(1, 2, [3u8; 32], [4u8; 32], [5u8; 32]),
-            current_sync_committee: committee,
-            current_sync_committee_branch: FixedVector::new(vec![[0u8; 32]; 5]).unwrap(),
-        };
-
-        let bytes = raw.as_ssz_bytes();
-        let bootstrap =
-            LightClientBootstrap::from_ssz(&bytes, Fork::Altair, 512, [0u8; 32]).unwrap();
-
-        assert_eq!(bootstrap.current_sync_committee.len(), 512);
-    }
 
     #[test]
     fn rejects_bad_committee_size() {


### PR DESCRIPTION
Follow-up to #93. `ssz.rs` is a wire *decoder* — every `Raw*` struct exists to be decoded via `from_ssz_bytes` — but all eight carried an unused `Encode` derive.

## What
- `Encode` was used in exactly one place: the `decodes_mainnet_sized_512_committee` test, which synthesized a mainnet-sized bootstrap to exercise the 512-committee path in the absence of official mainnet fixtures.
- Delete that test and strip `Encode` from all eight `Raw*` structs. The import drops to `use ssz_derive::Decode` and the module becomes a pure decoder. Net −23 lines.

## Coverage note
This removes the only test touching a 512 (mainnet) decode path — so the 512 paths (Capella/Deneb included) now have no coverage; only the 32 (minimal) paths are exercised via official fixtures. That coverage returns properly later with mainnet-preset sync-committee fixtures + 512 replay tests (tracks the README "mainnet-parameter coverage still pending" note).

## Verification
- `cargo clippy --all-targets --features test-utils -- -D warnings` — clean.
- `cargo test --features test-utils` — 49 unit + 4 integration + doc tests, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)