### PR TITLE
docs: expand consensus README Background — node roles, Transactions subsection

### DIFF
--- a/src/consensus/README.md
+++ b/src/consensus/README.md
@@ -18,17 +18,27 @@ Table of Contents:
 
 ## 1. Blockchains
 ### Public Blockchains
-Public blockchains, like Bitcoin and Ethereum, aim to be credibly neutral digital ledgers which anyone can interact with and no one can unilaterally control.  This class of blockchains act as trustless, programmatic intermediaries to facilitate coordination within the digital world. 
+Public blockchains, like Bitcoin and Ethereum, aim to be credibly neutral digital ledgers which anyone can interact with and no one can unilaterally control.  This class of blockchains act as trustless, programmatic intermediaries to facilitate coordination throughout the digital world. 
 
-Unlike traditional authoritative databases (e.g. the Fed's ledger), public blockchains are explicitly designed to *not* be controlled by a central operator; it would degrade one such system's credible neutrality.  Instead, these ledgers are meant to be simultaneously kept by large networks of independently operated computers.  With public blockchains, anyone can join the network.
+Unlike traditional authoritative databases (e.g. the Federal Reserve's ledger), public blockchains are explicitly designed to *not* be controlled by a central operator; it would degrade one such system's credible neutrality.  Instead, these ledgers are meant to be simultaneously kept by large networks of independently operated computers.  
+
+Nodes within a blockchain's network (i) each store their own copy of the ledger, (ii) verify the ledger's information is sound and (iii) help propagate information to other nodes, so everyone's copy of the ledger can be in sync.  
+
+People operate nodes by running open-source software that implements a blockchain's governing ruleset- its protocol.  With public blockchains, anyone can operate a node to help contribute to the network.  This combination of open-source protocol + public participation in the network is foundational to a blockchain's resilience.
 
 **Note:** In this doc from here on out, "blockchain" will be shorthand for "public blockchain".
 
-Nodes within a blockchain's network (i) each verify the ledger's information is sound and (ii) help propagate information to other nodes.  They do this by running open-source software that implements a blockchain's governing ruleset- its protocol.
+### Transactions, Blocks, and An Asynchronous Network
+#### Transactions
+Users trustlessly coordinate with one another by creating transactions that update the ledger.  Transactions must follow rules defined within the protocol and are always grounded in the reality of the current ledger's state. For example, Alice can send Bob 1 BTC *if* the ledger says she has at least 1 BTC at the time of her request.
 
-This combination of open-source protocol + public participation in the network is foundational to a blockchain's resilience.
+To create a transaction, a user sends a transaction request to a node in the network.  This node independently verifies the request follows protocol rules, and spreads it to other nodes.  Other nodes then do the same, until the request has propogated throughout the network.
 
-### Transactions, Blocks, and State
+In an effort to keep nodes on the same page, propogated transaction requests don't get applied to the ledger immediately; they sit inside nodes' storage as pending.
+
+#### Blocks
+
+#### An Asynchronous Network
 
 ### Safety and Liveness
 


### PR DESCRIPTION
Continues the conceptual Background explainer in `src/consensus/README.md`.

- Expands **Public Blockchains** with node roles (store own copy, verify, propagate) and the open-source-protocol + public-participation → resilience point.
- Adds the **Transactions** subsection (trustless coordination, rule-bound + grounded in current state with an Alice/Bob example; submission → gossip → pending).
- Renames the section to **Transactions, Blocks, and An Asynchronous Network** and stubs the **Blocks** and **An Asynchronous Network** subsections.

Docs-only; no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)