### PR TITLE
docs: point root README explainer link at docs/consensus-primer.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Differences stem from one thing: a full node *re-derives* the chain's validity f
 - Browsers/extensions: “Show accurate chain status without trusting an RPC.”
 - Embedded / constrained devices: verify minimal facts with minimal resources.
 
-For a module-by-module map of the crate, see [`src/README.md`](src/README.md).  For an in-depth explainer on the light client sync protocol, and verification data flow and correctness invariants, see [`src/consensus/README.md`](src/consensus/README.md).
+For a module-by-module map of the crate, see [`src/README.md`](src/README.md).  For an in-depth explainer on the light client sync protocol, see [`docs/consensus-primer.md`](docs/consensus-primer.md); for the verification data flow and correctness invariants, see [`src/consensus/README.md`](src/consensus/README.md).
 
 ## Status
 The library currently supports fork-aware light client verification through **Deneb**.


### PR DESCRIPTION
Follow-up to #103. The in-depth conceptual explainer moved to `docs/consensus-primer.md`, but the root README still pointed the "explainer" reference at `src/consensus/README.md`.

Splits the previously-combined reference so each half targets the correct file:
- **explainer on the light client sync protocol** → `docs/consensus-primer.md`
- **verification data flow and correctness invariants** → `src/consensus/README.md`

Wording otherwise unchanged. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)