### PR TITLE
refactor: config module scrutiny pass (#110)

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -68,14 +68,13 @@ flowchart TD
 
     main["mainnet()"] --> fc
     min["minimal()"] --> fc
-    ft["for_test()"] --> fc
 
     fc --> spec["ChainSpec<br/>validated<br/>immutable · trusted"]
 ```
 
 The validated door (`try_from_config`) is the only path that checks input; the
-trusted presets (`minimal`, `mainnet`, `for_test`) skip `validate()` as a
-`const` construction optimization but still go through the single `from_config`
+trusted presets (`minimal`, `mainnet`) skip `validate()` as a `const`
+construction optimization but still go through the single `from_config`
 mapping. Their params are known-good, so `try_from_config` would accept them
 just the same.
 

--- a/src/README.md
+++ b/src/README.md
@@ -82,3 +82,13 @@ just the same.
 `config` sits near the **floor** of the dependency graph (depends only on `error` + `types::primitives`); nearly everything consensus-y depends on it. So it's foundational.  The module should be stable and low-churn.
 
 It's also where each **new fork lands** (a `ForkParams`, a gindex arm, a fork version) as support advances (Deneb → Electra → Fulu).
+
+What each fork changed, light-client-wise (`Fork` enum variants, in order):
+
+| Fork | LC-relevant change |
+|------|--------------------|
+| Altair (Oct 2021) | Light client protocol introduced |
+| Bellatrix (Sep 2022) | The Merge; no LC header changes |
+| Capella (Apr 2023) | LC header gains the execution payload header + inclusion branch |
+| Deneb (Mar 2024) | Blobs/4844; execution payload header adds blob-gas fields |
+| Electra (2025) | Pectra; BeaconState restructured — gindices shift, proof branches deepen |

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,9 @@ use crate::types::primitives::Slot;
 /// that apply. Used by [`ChainSpec`] internally and by the public
 /// `LightClient{Update,Bootstrap}::from_ssz` decoders to pick the wire format.
 //
-// TODO: Check to see if macros are needed. Remove explanatory field comments. move inside this directory's readme.
+// TODO:
+//    - Check to see if macros are needed.
+//    - Remove explanatory field comments. move inside this directory's readme.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum Fork {
@@ -16,6 +18,7 @@ pub enum Fork {
     Electra,   // Pectra upgrade (2025). BeaconState restructured, gindice change.
 }
 
+// TODO: Should we move fork / fork schedule below the config struct?
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ForkSchedule {
     altair: ForkParams,
@@ -87,8 +90,7 @@ impl ForkParams {
     }
 }
 
-/// Defines network-specific constants for mainnet/minimal (test) presets.
-/// Includes fork schedule and fork-specific constants.
+/// Defines network-specific constants. Includes fork schedule and fork-specific constants.
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 pub struct ChainSpec {
@@ -100,7 +102,6 @@ pub struct ChainSpec {
     fork_schedule: ForkSchedule,
 }
 
-// TODO: Rethink whether the ChainSpec struct + constructors make sense.
 impl ChainSpec {
     pub const fn mainnet() -> Self {
         Self::from_config(ChainSpecConfig::mainnet())
@@ -133,21 +134,8 @@ impl ChainSpec {
         }
     }
 
-    // TODO: Scrutinize each associated method.  Assess necessity.
-    pub const fn genesis_time(&self) -> u64 {
-        self.genesis_time
-    }
-
-    pub const fn seconds_per_slot(&self) -> u64 {
-        self.seconds_per_slot
-    }
-
     pub const fn slots_per_epoch(&self) -> u64 {
         self.slots_per_epoch
-    }
-
-    pub const fn epochs_per_sync_committee_period(&self) -> u64 {
-        self.epochs_per_sync_committee_period
     }
 
     pub const fn sync_committee_size(&self) -> usize {
@@ -166,18 +154,12 @@ impl ChainSpec {
         self.slot_to_epoch(slot) / self.epochs_per_sync_committee_period
     }
 
-    pub const fn sync_committee_period_start_slot(&self, period: u64) -> u64 {
-        period * self.slots_per_sync_committee_period()
-    }
-
-    pub const fn sync_committee_period_end_slot(&self, period: u64) -> u64 {
-        self.sync_committee_period_start_slot(period + 1) - 1
-    }
-
-    /// Calculate current slot from Unix timestamp
+    /// Current slot from a Unix timestamp.
     ///
-    /// Returns 0 if the timestamp is before genesis (e.g., system clock is wrong)
-    // TODO: Should this return an error instead of `0`?
+    /// Pre-genesis timestamps map to slot 0 — fail-closed: a wrong/early clock
+    /// lowers `current_slot`, and validation rejects updates with
+    /// `signature_slot > current_slot`, so a bad clock rejects more, never
+    /// accepts more.
     pub(crate) fn timestamp_to_slot(&self, timestamp_secs: u64) -> u64 {
         if timestamp_secs >= self.genesis_time {
             (timestamp_secs - self.genesis_time) / self.seconds_per_slot
@@ -202,12 +184,6 @@ impl ChainSpec {
         self.fork_schedule.version_at_epoch(epoch)
     }
 
-    // Beacon State Generalized Indices
-    //
-    // These return the SSZ generalized index for various beacon state fields.
-    // Indices changed in Electra due to BeaconState restructuring.
-    //
-    // Reference: https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/sync-protocol.md
     #[inline]
     pub(crate) const fn current_sync_committee_gindex(&self, slot: Slot) -> u64 {
         match self.fork_at_slot(slot) {
@@ -216,7 +192,6 @@ impl ChainSpec {
         }
     }
 
-    /// Get the generalized index for `BeaconState.next_sync_committee` at a given slot.
     #[inline]
     pub(crate) const fn next_sync_committee_gindex(&self, slot: Slot) -> u64 {
         match self.fork_at_slot(slot) {
@@ -225,7 +200,6 @@ impl ChainSpec {
         }
     }
 
-    /// Get the generalized index for `BeaconState.finalized_checkpoint.root` at a given slot.
     #[inline]
     pub(crate) const fn finalized_root_gindex(&self, slot: Slot) -> u64 {
         match self.fork_at_slot(slot) {
@@ -257,7 +231,7 @@ impl ChainSpec {
 /// };
 ///
 /// let spec = ChainSpec::try_from_config(config).unwrap();
-/// assert_eq!(spec.genesis_time(), 1700000000);
+/// assert_eq!(spec.slots_per_epoch(), 8); // minimal-preset value carried through
 /// ```
 
 #[derive(Debug, Clone, Copy)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,8 @@ use crate::types::primitives::Slot;
 /// Identifies a consensus fork, selecting the light client wire layout / rules
 /// that apply. Used by [`ChainSpec`] internally and by the public
 /// `LightClient{Update,Bootstrap}::from_ssz` decoders to pick the wire format.
+//
+// TODO: Check to see if macros are needed. Remove explanatory field comments. move inside this directory's readme.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum Fork {
@@ -87,12 +89,9 @@ impl ForkParams {
 
 /// Defines network-specific constants for mainnet/minimal (test) presets.
 /// Includes fork schedule and fork-specific constants.
-//
-// TODO: Should the preset be an enum with types `mainnet`, `minimal`, or `custom`?
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 pub struct ChainSpec {
-    preset_name: &'static str,
     genesis_time: u64,
     seconds_per_slot: u64,
     slots_per_epoch: u64,
@@ -104,22 +103,21 @@ pub struct ChainSpec {
 // TODO: Rethink whether the ChainSpec struct + constructors make sense.
 impl ChainSpec {
     pub const fn mainnet() -> Self {
-        Self::from_config(ChainSpecConfig::mainnet(), "mainnet")
+        Self::from_config(ChainSpecConfig::mainnet())
     }
 
     pub const fn minimal() -> Self {
-        Self::from_config(ChainSpecConfig::minimal(), "minimal")
+        Self::from_config(ChainSpecConfig::minimal())
     }
 
     pub fn try_from_config(config: ChainSpecConfig) -> Result<Self> {
         config.validate()?;
-        Ok(Self::from_config(config, "custom"))
+        Ok(Self::from_config(config))
     }
 
     /// The one place the config -> spec mapping lives; callers own validation.
-    const fn from_config(config: ChainSpecConfig, preset_name: &'static str) -> Self {
+    const fn from_config(config: ChainSpecConfig) -> Self {
         Self {
-            preset_name,
             genesis_time: config.genesis_time,
             seconds_per_slot: config.seconds_per_slot,
             slots_per_epoch: config.slots_per_epoch,
@@ -136,10 +134,6 @@ impl ChainSpec {
     }
 
     // TODO: Scrutinize each associated method.  Assess necessity.
-    pub const fn preset_name(&self) -> &'static str {
-        self.preset_name
-    }
-
     pub const fn genesis_time(&self) -> u64 {
         self.genesis_time
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,90 +4,15 @@ use crate::types::primitives::Slot;
 /// Identifies a consensus fork, selecting the light client wire layout / rules
 /// that apply. Used by [`ChainSpec`] internally and by the public
 /// `LightClient{Update,Bootstrap}::from_ssz` decoders to pick the wire format.
-//
-// TODO:
-//    - Check to see if macros are needed.
-//    - Remove explanatory field comments. move inside this directory's readme.
+/// For what each fork changed light-client-wise, see `src/README.md`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum Fork {
-    Altair,    // Light client protocol introduced (Oct 2021)
-    Bellatrix, // The Merge (Sep 2022). No LC header changes.
-    Capella,   // Withdrawals (Apr 2023). LC header gains execution payload.
-    Deneb,     // Blobs/4844 (Mar 2024). LC header adds blob fields.
-    Electra,   // Pectra upgrade (2025). BeaconState restructured, gindice change.
-}
-
-// TODO: Should we move fork / fork schedule below the config struct?
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct ForkSchedule {
-    altair: ForkParams,
-    bellatrix: ForkParams,
-    capella: ForkParams,
-    deneb: ForkParams,
-    electra: ForkParams,
-}
-
-impl ForkSchedule {
-    pub(crate) const fn new(
-        altair: ForkParams,
-        bellatrix: ForkParams,
-        capella: ForkParams,
-        deneb: ForkParams,
-        electra: ForkParams,
-    ) -> Self {
-        Self {
-            altair,
-            bellatrix,
-            capella,
-            deneb,
-            electra,
-        }
-    }
-
-    pub(crate) const fn fork_at_epoch(&self, epoch: u64) -> Fork {
-        if epoch >= self.electra.epoch() {
-            Fork::Electra
-        } else if epoch >= self.deneb.epoch() {
-            Fork::Deneb
-        } else if epoch >= self.capella.epoch() {
-            Fork::Capella
-        } else if epoch >= self.bellatrix.epoch() {
-            Fork::Bellatrix
-        } else {
-            Fork::Altair
-        }
-    }
-
-    pub(crate) const fn version_at_epoch(&self, epoch: u64) -> [u8; 4] {
-        match self.fork_at_epoch(epoch) {
-            Fork::Altair => self.altair.version(),
-            Fork::Bellatrix => self.bellatrix.version(),
-            Fork::Capella => self.capella.version(),
-            Fork::Deneb => self.deneb.version(),
-            Fork::Electra => self.electra.version(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct ForkParams {
-    version: [u8; 4],
-    epoch: u64,
-}
-
-impl ForkParams {
-    pub(crate) const fn new(version: [u8; 4], epoch: u64) -> Self {
-        Self { version, epoch }
-    }
-
-    pub(crate) const fn version(&self) -> [u8; 4] {
-        self.version
-    }
-
-    pub(crate) const fn epoch(&self) -> u64 {
-        self.epoch
-    }
+    Altair,
+    Bellatrix,
+    Capella,
+    Deneb,
+    Electra,
 }
 
 /// Defines network-specific constants. Includes fork schedule and fork-specific constants.
@@ -206,6 +131,77 @@ impl ChainSpec {
             Fork::Electra => 169,
             _ => 105,
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ForkSchedule {
+    altair: ForkParams,
+    bellatrix: ForkParams,
+    capella: ForkParams,
+    deneb: ForkParams,
+    electra: ForkParams,
+}
+
+impl ForkSchedule {
+    pub(crate) const fn new(
+        altair: ForkParams,
+        bellatrix: ForkParams,
+        capella: ForkParams,
+        deneb: ForkParams,
+        electra: ForkParams,
+    ) -> Self {
+        Self {
+            altair,
+            bellatrix,
+            capella,
+            deneb,
+            electra,
+        }
+    }
+
+    pub(crate) const fn fork_at_epoch(&self, epoch: u64) -> Fork {
+        if epoch >= self.electra.epoch() {
+            Fork::Electra
+        } else if epoch >= self.deneb.epoch() {
+            Fork::Deneb
+        } else if epoch >= self.capella.epoch() {
+            Fork::Capella
+        } else if epoch >= self.bellatrix.epoch() {
+            Fork::Bellatrix
+        } else {
+            Fork::Altair
+        }
+    }
+
+    pub(crate) const fn version_at_epoch(&self, epoch: u64) -> [u8; 4] {
+        match self.fork_at_epoch(epoch) {
+            Fork::Altair => self.altair.version(),
+            Fork::Bellatrix => self.bellatrix.version(),
+            Fork::Capella => self.capella.version(),
+            Fork::Deneb => self.deneb.version(),
+            Fork::Electra => self.electra.version(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ForkParams {
+    version: [u8; 4],
+    epoch: u64,
+}
+
+impl ForkParams {
+    pub(crate) const fn new(version: [u8; 4], epoch: u64) -> Self {
+        Self { version, epoch }
+    }
+
+    pub(crate) const fn version(&self) -> [u8; 4] {
+        self.version
+    }
+
+    pub(crate) const fn epoch(&self) -> u64 {
+        self.epoch
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -186,12 +186,12 @@ impl ChainSpec {
         }
     }
 
-    pub(crate) const fn fork_at_epoch(&self, epoch: u64) -> Fork {
+    const fn fork_at_epoch(&self, epoch: u64) -> Fork {
         self.fork_schedule.fork_at_epoch(epoch)
     }
 
     /// Determine which fork is active at a given slot.
-    pub(crate) const fn fork_at_slot(&self, slot: Slot) -> Fork {
+    const fn fork_at_slot(&self, slot: Slot) -> Fork {
         self.fork_at_epoch(slot / self.slots_per_epoch)
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,6 @@ pub enum Fork {
 
 /// Defines network-specific constants. Includes fork schedule and fork-specific constants.
 #[derive(Debug, Clone)]
-#[non_exhaustive]
 pub struct ChainSpec {
     genesis_time: u64,
     seconds_per_slot: u64,
@@ -75,8 +74,6 @@ impl ChainSpec {
         self.slot_to_epoch(slot) / self.epochs_per_sync_committee_period
     }
 
-    /// Current slot from a Unix timestamp.
-    ///
     /// Pre-genesis timestamps map to slot 0 — fail-closed: a wrong/early clock
     /// lowers `current_slot`, and validation rejects updates with
     /// `signature_slot > current_slot`, so a bad clock rejects more, never
@@ -301,7 +298,7 @@ impl ChainSpecConfig {
             ));
         }
 
-        // TODO: Figure out *why* these are the only two permitted sync committee sizes... this seems unnecessary, and at the very least, unnecessarily opaque.
+        // Must match a compiled decoder shape (32 minimal / 512 mainnet).  See dispatch in types/ssz.rs
         if self.sync_committee_size != 32 && self.sync_committee_size != 512 {
             return Err(Error::InvalidInput(
                 "sync_committee_size must be 32 or 512".to_string(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -98,7 +98,6 @@ impl ChainSpec {
         self.fork_schedule.version_at_epoch(epoch)
     }
 
-    #[inline]
     pub(crate) const fn current_sync_committee_gindex(&self, slot: Slot) -> u64 {
         match self.fork_at_slot(slot) {
             Fork::Electra => 86,
@@ -106,7 +105,6 @@ impl ChainSpec {
         }
     }
 
-    #[inline]
     pub(crate) const fn next_sync_committee_gindex(&self, slot: Slot) -> u64 {
         match self.fork_at_slot(slot) {
             Fork::Electra => 87,
@@ -114,7 +112,6 @@ impl ChainSpec {
         }
     }
 
-    #[inline]
     pub(crate) const fn finalized_root_gindex(&self, slot: Slot) -> u64 {
         match self.fork_at_slot(slot) {
             Fork::Electra => 169,

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,7 @@ pub enum Fork {
 }
 
 /// Defines network-specific constants. Includes fork schedule and fork-specific constants.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct ChainSpec {
     genesis_time: u64,
@@ -126,7 +126,7 @@ impl ChainSpec {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(crate) struct ForkSchedule {
     altair: ForkParams,
     bellatrix: ForkParams,
@@ -177,7 +177,7 @@ impl ForkSchedule {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(crate) struct ForkParams {
     version: [u8; 4],
     epoch: u64,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,11 +1,7 @@
 use crate::error::{Error, Result};
 use crate::types::primitives::Slot;
 
-/// Identifies a consensus fork, selecting the light client wire layout / rules
-/// that apply. Used by [`ChainSpec`] internally and by the public
-/// `LightClient{Update,Bootstrap}::from_ssz` decoders to pick the wire format.
-/// For what each fork changed light-client-wise, see `src/README.md`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Fork {
     Altair,
@@ -97,14 +93,10 @@ impl ChainSpec {
         self.fork_schedule.fork_at_epoch(epoch)
     }
 
-    /// Determine which fork is active at a given slot.
     const fn fork_at_slot(&self, slot: Slot) -> Fork {
         self.fork_at_epoch(slot / self.slots_per_epoch)
     }
 
-    /// Get the fork version for a given epoch.
-    ///
-    /// Used for computing signature domains.
     pub(crate) const fn fork_version_at_epoch(&self, epoch: u64) -> [u8; 4] {
         self.fork_schedule.version_at_epoch(epoch)
     }
@@ -134,7 +126,7 @@ impl ChainSpec {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct ForkSchedule {
     altair: ForkParams,
     bellatrix: ForkParams,
@@ -185,7 +177,7 @@ impl ForkSchedule {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct ForkParams {
     version: [u8; 4],
     epoch: u64,

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,6 @@ pub enum Fork {
     Electra,   // Pectra upgrade (2025). BeaconState restructured, gindice change.
 }
 
-/// Complete fork schedule for a network.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ForkSchedule {
     altair: ForkParams,
@@ -41,7 +40,6 @@ impl ForkSchedule {
         }
     }
 
-    /// Determine which fork is active at a given epoch.
     pub(crate) const fn fork_at_epoch(&self, epoch: u64) -> Fork {
         if epoch >= self.electra.epoch() {
             Fork::Electra
@@ -56,7 +54,6 @@ impl ForkSchedule {
         }
     }
 
-    /// Get the fork version for a given epoch.
     pub(crate) const fn version_at_epoch(&self, epoch: u64) -> [u8; 4] {
         match self.fork_at_epoch(epoch) {
             Fork::Altair => self.altair.version(),
@@ -68,7 +65,6 @@ impl ForkSchedule {
     }
 }
 
-/// Fork version and activation epoch for a single fork.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ForkParams {
     version: [u8; 4],
@@ -89,6 +85,162 @@ impl ForkParams {
     }
 }
 
+/// Defines network-specific constants for mainnet/minimal (test) presets.
+/// Includes fork schedule and fork-specific constants.
+//
+// TODO: Should the preset be an enum with types `mainnet`, `minimal`, or `custom`?
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub struct ChainSpec {
+    preset_name: &'static str,
+    genesis_time: u64,
+    seconds_per_slot: u64,
+    slots_per_epoch: u64,
+    epochs_per_sync_committee_period: u64,
+    sync_committee_size: usize,
+    fork_schedule: ForkSchedule,
+}
+
+// TODO: Rethink whether the ChainSpec struct + constructors make sense.
+impl ChainSpec {
+    pub const fn mainnet() -> Self {
+        Self::from_config(ChainSpecConfig::mainnet(), "mainnet")
+    }
+
+    pub const fn minimal() -> Self {
+        Self::from_config(ChainSpecConfig::minimal(), "minimal")
+    }
+
+    pub fn try_from_config(config: ChainSpecConfig) -> Result<Self> {
+        config.validate()?;
+        Ok(Self::from_config(config, "custom"))
+    }
+
+    /// The one place the config -> spec mapping lives; callers own validation.
+    const fn from_config(config: ChainSpecConfig, preset_name: &'static str) -> Self {
+        Self {
+            preset_name,
+            genesis_time: config.genesis_time,
+            seconds_per_slot: config.seconds_per_slot,
+            slots_per_epoch: config.slots_per_epoch,
+            epochs_per_sync_committee_period: config.epochs_per_sync_committee_period,
+            sync_committee_size: config.sync_committee_size,
+            fork_schedule: ForkSchedule::new(
+                ForkParams::new(config.altair_fork_version, config.altair_fork_epoch),
+                ForkParams::new(config.bellatrix_fork_version, config.bellatrix_fork_epoch),
+                ForkParams::new(config.capella_fork_version, config.capella_fork_epoch),
+                ForkParams::new(config.deneb_fork_version, config.deneb_fork_epoch),
+                ForkParams::new(config.electra_fork_version, config.electra_fork_epoch),
+            ),
+        }
+    }
+
+    // TODO: Scrutinize each associated method.  Assess necessity.
+    pub const fn preset_name(&self) -> &'static str {
+        self.preset_name
+    }
+
+    pub const fn genesis_time(&self) -> u64 {
+        self.genesis_time
+    }
+
+    pub const fn seconds_per_slot(&self) -> u64 {
+        self.seconds_per_slot
+    }
+
+    pub const fn slots_per_epoch(&self) -> u64 {
+        self.slots_per_epoch
+    }
+
+    pub const fn epochs_per_sync_committee_period(&self) -> u64 {
+        self.epochs_per_sync_committee_period
+    }
+
+    pub const fn sync_committee_size(&self) -> usize {
+        self.sync_committee_size
+    }
+
+    pub const fn slots_per_sync_committee_period(&self) -> u64 {
+        self.slots_per_epoch * self.epochs_per_sync_committee_period
+    }
+
+    pub(crate) const fn slot_to_epoch(&self, slot: u64) -> u64 {
+        slot / self.slots_per_epoch
+    }
+
+    pub(crate) const fn slot_to_sync_committee_period(&self, slot: u64) -> u64 {
+        self.slot_to_epoch(slot) / self.epochs_per_sync_committee_period
+    }
+
+    pub const fn sync_committee_period_start_slot(&self, period: u64) -> u64 {
+        period * self.slots_per_sync_committee_period()
+    }
+
+    pub const fn sync_committee_period_end_slot(&self, period: u64) -> u64 {
+        self.sync_committee_period_start_slot(period + 1) - 1
+    }
+
+    /// Calculate current slot from Unix timestamp
+    ///
+    /// Returns 0 if the timestamp is before genesis (e.g., system clock is wrong)
+    // TODO: Should this return an error instead of `0`?
+    pub(crate) fn timestamp_to_slot(&self, timestamp_secs: u64) -> u64 {
+        if timestamp_secs >= self.genesis_time {
+            (timestamp_secs - self.genesis_time) / self.seconds_per_slot
+        } else {
+            0
+        }
+    }
+
+    pub(crate) const fn fork_at_epoch(&self, epoch: u64) -> Fork {
+        self.fork_schedule.fork_at_epoch(epoch)
+    }
+
+    /// Determine which fork is active at a given slot.
+    pub(crate) const fn fork_at_slot(&self, slot: Slot) -> Fork {
+        self.fork_at_epoch(slot / self.slots_per_epoch)
+    }
+
+    /// Get the fork version for a given epoch.
+    ///
+    /// Used for computing signature domains.
+    pub(crate) const fn fork_version_at_epoch(&self, epoch: u64) -> [u8; 4] {
+        self.fork_schedule.version_at_epoch(epoch)
+    }
+
+    // Beacon State Generalized Indices
+    //
+    // These return the SSZ generalized index for various beacon state fields.
+    // Indices changed in Electra due to BeaconState restructuring.
+    //
+    // Reference: https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/sync-protocol.md
+    #[inline]
+    pub(crate) const fn current_sync_committee_gindex(&self, slot: Slot) -> u64 {
+        match self.fork_at_slot(slot) {
+            Fork::Electra => 86,
+            _ => 54,
+        }
+    }
+
+    /// Get the generalized index for `BeaconState.next_sync_committee` at a given slot.
+    #[inline]
+    pub(crate) const fn next_sync_committee_gindex(&self, slot: Slot) -> u64 {
+        match self.fork_at_slot(slot) {
+            Fork::Electra => 87,
+            _ => 55,
+        }
+    }
+
+    /// Get the generalized index for `BeaconState.finalized_checkpoint.root` at a given slot.
+    #[inline]
+    pub(crate) const fn finalized_root_gindex(&self, slot: Slot) -> u64 {
+        match self.fork_at_slot(slot) {
+            Fork::Electra => 169,
+            _ => 105,
+        }
+    }
+}
+
 /// Configurations for creating a [`ChainSpec`].
 ///
 /// For mainnet, use [`ChainSpec::mainnet()`].
@@ -97,25 +249,17 @@ impl ForkParams {
 ///
 /// # Example
 ///
+/// Start from a preset and override what differs; [`ChainSpec::try_from_config`]
+/// validates the result (e.g. fork-epoch ordering):
+///
 /// ```
 /// use eth_light_client::{ChainSpec, ChainSpecConfig};
 ///
 /// let config = ChainSpecConfig {
 ///     genesis_time: 1700000000,
-///     seconds_per_slot: 12,
-///     slots_per_epoch: 32,
-///     epochs_per_sync_committee_period: 256,
-///     sync_committee_size: 512,
-///     altair_fork_version: [0x01, 0x00, 0x00, 0x00],
-///     bellatrix_fork_version: [0x02, 0x00, 0x00, 0x00],
-///     capella_fork_version: [0x03, 0x00, 0x00, 0x00],
-///     deneb_fork_version: [0x04, 0x00, 0x00, 0x00],
-///     electra_fork_version: [0x05, 0x00, 0x00, 0x00],
-///     altair_fork_epoch: 0,
 ///     bellatrix_fork_epoch: 10,
 ///     capella_fork_epoch: 20,
-///     deneb_fork_epoch: 30,
-///     electra_fork_epoch: 40,
+///     ..ChainSpecConfig::minimal()
 /// };
 ///
 /// let spec = ChainSpec::try_from_config(config).unwrap();
@@ -128,7 +272,6 @@ pub struct ChainSpecConfig {
     pub seconds_per_slot: u64,
     pub slots_per_epoch: u64,
     pub epochs_per_sync_committee_period: u64,
-    /// Must be 32 (minimal) or 512 (mainnet).
     pub sync_committee_size: usize,
 
     pub altair_fork_version: [u8; 4],
@@ -137,8 +280,6 @@ pub struct ChainSpecConfig {
     pub deneb_fork_version: [u8; 4],
     pub electra_fork_version: [u8; 4],
 
-    /// Altair activation epoch; the monotonic floor of the fork schedule
-    /// (may be nonzero, e.g. mainnet's 74240).
     pub altair_fork_epoch: u64,
     pub bellatrix_fork_epoch: u64,
     pub capella_fork_epoch: u64,
@@ -204,14 +345,14 @@ impl ChainSpecConfig {
             ));
         }
 
-        // Strict validation: only 32 or 512 are valid sync committee sizes
+        // TODO: Figure out *why* these are the only two permitted sync committee sizes... this seems unnecessary, and at the very least, unnecessarily opaque.
         if self.sync_committee_size != 32 && self.sync_committee_size != 512 {
             return Err(Error::InvalidInput(
                 "sync_committee_size must be 32 or 512".to_string(),
             ));
         }
 
-        // Fork epochs must be monotonically non-decreasing, anchored at Altair. The light client operates from Altair onward via its trusted bootstrap, so Altair may activate at any epoch (e.g. mainnet at 74240), not only genesis — it just cannot come after a later fork.
+        // Fork epochs are monotonically non-decreasing, anchored at Altair.
         if self.bellatrix_fork_epoch < self.altair_fork_epoch {
             return Err(Error::InvalidInput(
                 "bellatrix_fork_epoch must be >= altair_fork_epoch".to_string(),
@@ -234,200 +375,6 @@ impl ChainSpecConfig {
         }
 
         Ok(())
-    }
-}
-
-/// Defines network-specific constants for mainnet and minimal (test) presets.
-/// Includes fork schedule and fork-specific constants.
-#[derive(Debug, Clone, Copy)]
-#[non_exhaustive]
-pub struct ChainSpec {
-    preset_name: &'static str,
-    genesis_time: u64,
-    seconds_per_slot: u64,
-    slots_per_epoch: u64,
-    epochs_per_sync_committee_period: u64,
-    sync_committee_size: usize,
-    fork_schedule: ForkSchedule,
-}
-
-impl ChainSpec {
-    pub const fn mainnet() -> Self {
-        Self::from_config(ChainSpecConfig::mainnet(), "mainnet")
-    }
-
-    pub const fn minimal() -> Self {
-        Self::from_config(ChainSpecConfig::minimal(), "minimal")
-    }
-
-    /// Use this for local testnets or devnets with non-standard parameters.
-    pub fn try_from_config(config: ChainSpecConfig) -> Result<Self> {
-        config.validate()?;
-        Ok(Self::from_config(config, "custom"))
-    }
-
-    /// The one place the config -> spec mapping lives; callers own validation.
-    const fn from_config(config: ChainSpecConfig, preset_name: &'static str) -> Self {
-        Self {
-            preset_name,
-            genesis_time: config.genesis_time,
-            seconds_per_slot: config.seconds_per_slot,
-            slots_per_epoch: config.slots_per_epoch,
-            epochs_per_sync_committee_period: config.epochs_per_sync_committee_period,
-            sync_committee_size: config.sync_committee_size,
-            fork_schedule: ForkSchedule::new(
-                ForkParams::new(config.altair_fork_version, config.altair_fork_epoch),
-                ForkParams::new(config.bellatrix_fork_version, config.bellatrix_fork_epoch),
-                ForkParams::new(config.capella_fork_version, config.capella_fork_epoch),
-                ForkParams::new(config.deneb_fork_version, config.deneb_fork_epoch),
-                ForkParams::new(config.electra_fork_version, config.electra_fork_epoch),
-            ),
-        }
-    }
-
-    /// Test constructor for creating custom specs (e.g., fork boundary tests).
-    #[cfg(test)]
-    pub(crate) fn for_test(
-        slots_per_epoch: u64,
-        altair_fork_version: [u8; 4],
-        bellatrix_fork_version: [u8; 4],
-        altair_fork_epoch: u64,
-        bellatrix_fork_epoch: u64,
-    ) -> Self {
-        // Later forks are pinned past reach (u64::MAX), so their versions are
-        // never active; values are placeholders. from_config keeps this on the
-        // single config->spec mapping.
-        Self::from_config(
-            ChainSpecConfig {
-                genesis_time: 0,
-                seconds_per_slot: 12,
-                slots_per_epoch,
-                epochs_per_sync_committee_period: 8,
-                sync_committee_size: 32,
-                altair_fork_version,
-                bellatrix_fork_version,
-                capella_fork_version: [0x03, 0x00, 0x00, 0x00],
-                deneb_fork_version: [0x04, 0x00, 0x00, 0x00],
-                electra_fork_version: [0x05, 0x00, 0x00, 0x00],
-                altair_fork_epoch,
-                bellatrix_fork_epoch,
-                capella_fork_epoch: u64::MAX,
-                deneb_fork_epoch: u64::MAX,
-                electra_fork_epoch: u64::MAX,
-            },
-            "test",
-        )
-    }
-
-    pub const fn preset_name(&self) -> &'static str {
-        self.preset_name
-    }
-
-    pub const fn genesis_time(&self) -> u64 {
-        self.genesis_time
-    }
-
-    pub const fn seconds_per_slot(&self) -> u64 {
-        self.seconds_per_slot
-    }
-
-    pub const fn slots_per_epoch(&self) -> u64 {
-        self.slots_per_epoch
-    }
-
-    pub const fn epochs_per_sync_committee_period(&self) -> u64 {
-        self.epochs_per_sync_committee_period
-    }
-
-    pub const fn sync_committee_size(&self) -> usize {
-        self.sync_committee_size
-    }
-
-    /// Calculate total slots per sync committee period
-    pub const fn slots_per_sync_committee_period(&self) -> u64 {
-        self.slots_per_epoch * self.epochs_per_sync_committee_period
-    }
-
-    /// Convert slot to epoch
-    pub(crate) const fn slot_to_epoch(&self, slot: u64) -> u64 {
-        slot / self.slots_per_epoch
-    }
-
-    /// Convert slot to sync committee period
-    pub(crate) const fn slot_to_sync_committee_period(&self, slot: u64) -> u64 {
-        self.slot_to_epoch(slot) / self.epochs_per_sync_committee_period
-    }
-
-    /// Get start slot of a sync committee period
-    pub const fn sync_committee_period_start_slot(&self, period: u64) -> u64 {
-        period * self.slots_per_sync_committee_period()
-    }
-
-    /// Get end slot of a sync committee period (inclusive)
-    pub const fn sync_committee_period_end_slot(&self, period: u64) -> u64 {
-        self.sync_committee_period_start_slot(period + 1) - 1
-    }
-
-    /// Calculate current slot from Unix timestamp
-    ///
-    /// Returns 0 if the timestamp is before genesis (e.g., system clock is wrong)
-    pub(crate) fn timestamp_to_slot(&self, timestamp_secs: u64) -> u64 {
-        if timestamp_secs >= self.genesis_time {
-            (timestamp_secs - self.genesis_time) / self.seconds_per_slot
-        } else {
-            0
-        }
-    }
-
-    /// Determine which fork is active at a given epoch.
-    ///
-    /// Returns the highest fork whose activation epoch is <= the given epoch.
-    pub(crate) const fn fork_at_epoch(&self, epoch: u64) -> Fork {
-        self.fork_schedule.fork_at_epoch(epoch)
-    }
-
-    /// Determine which fork is active at a given slot.
-    pub(crate) const fn fork_at_slot(&self, slot: Slot) -> Fork {
-        self.fork_at_epoch(slot / self.slots_per_epoch)
-    }
-
-    /// Get the fork version for a given epoch.
-    ///
-    /// Used for computing signature domains.
-    pub(crate) const fn fork_version_at_epoch(&self, epoch: u64) -> [u8; 4] {
-        self.fork_schedule.version_at_epoch(epoch)
-    }
-
-    // Beacon State Generalized Indices
-    //
-    // These return the SSZ generalized index for various beacon state fields.
-    // Indices changed in Electra due to BeaconState restructuring.
-    //
-    // Reference: https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/sync-protocol.md
-    #[inline]
-    pub(crate) const fn current_sync_committee_gindex(&self, slot: Slot) -> u64 {
-        match self.fork_at_slot(slot) {
-            Fork::Electra => 86,
-            _ => 54,
-        }
-    }
-
-    /// Get the generalized index for `BeaconState.next_sync_committee` at a given slot.
-    #[inline]
-    pub(crate) const fn next_sync_committee_gindex(&self, slot: Slot) -> u64 {
-        match self.fork_at_slot(slot) {
-            Fork::Electra => 87,
-            _ => 55,
-        }
-    }
-
-    /// Get the generalized index for `BeaconState.finalized_checkpoint.root` at a given slot.
-    #[inline]
-    pub(crate) const fn finalized_root_gindex(&self, slot: Slot) -> u64 {
-        match self.fork_at_slot(slot) {
-            Fork::Electra => 169,
-            _ => 105,
-        }
     }
 }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -4,7 +4,7 @@ use super::*;
 fn test_mainnet_spec() {
     let spec = ChainSpec::mainnet();
     assert_eq!(spec.slots_per_epoch(), 32);
-    assert_eq!(spec.epochs_per_sync_committee_period(), 256);
+    assert_eq!(spec.epochs_per_sync_committee_period, 256);
     assert_eq!(spec.sync_committee_size(), 512);
     assert_eq!(spec.slots_per_sync_committee_period(), 8192);
     // Altair version via the live path (Altair is the genesis fork for the LC).
@@ -15,7 +15,7 @@ fn test_mainnet_spec() {
 fn test_minimal_spec() {
     let spec = ChainSpec::minimal();
     assert_eq!(spec.slots_per_epoch(), 8);
-    assert_eq!(spec.epochs_per_sync_committee_period(), 8);
+    assert_eq!(spec.epochs_per_sync_committee_period, 8);
     assert_eq!(spec.sync_committee_size(), 32);
     assert_eq!(spec.slots_per_sync_committee_period(), 64);
     assert_eq!(spec.fork_version_at_epoch(0), [0x01, 0x00, 0x00, 0x01]);
@@ -39,15 +39,6 @@ fn test_slot_to_period_minimal() {
     assert_eq!(spec.slot_to_sync_committee_period(64), 1);
     assert_eq!(spec.slot_to_sync_committee_period(127), 1);
     assert_eq!(spec.slot_to_sync_committee_period(128), 2);
-}
-
-#[test]
-fn test_period_boundaries() {
-    let spec = ChainSpec::minimal();
-    assert_eq!(spec.sync_committee_period_start_slot(0), 0);
-    assert_eq!(spec.sync_committee_period_end_slot(0), 63);
-    assert_eq!(spec.sync_committee_period_start_slot(1), 64);
-    assert_eq!(spec.sync_committee_period_end_slot(1), 127);
 }
 
 #[test]
@@ -245,10 +236,10 @@ fn test_chainspec_config_valid() {
     assert!(config.validate().is_ok());
 
     let spec = ChainSpec::try_from_config(config).unwrap();
-    assert_eq!(spec.genesis_time(), 1700000000);
-    assert_eq!(spec.seconds_per_slot(), 12);
+    assert_eq!(spec.genesis_time, 1700000000);
+    assert_eq!(spec.seconds_per_slot, 12);
     assert_eq!(spec.slots_per_epoch(), 32);
-    assert_eq!(spec.epochs_per_sync_committee_period(), 256);
+    assert_eq!(spec.epochs_per_sync_committee_period, 256);
     assert_eq!(spec.sync_committee_size(), 512);
 }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -3,7 +3,6 @@ use super::*;
 #[test]
 fn test_mainnet_spec() {
     let spec = ChainSpec::mainnet();
-    assert_eq!(spec.preset_name(), "mainnet");
     assert_eq!(spec.slots_per_epoch(), 32);
     assert_eq!(spec.epochs_per_sync_committee_period(), 256);
     assert_eq!(spec.sync_committee_size(), 512);
@@ -15,7 +14,6 @@ fn test_mainnet_spec() {
 #[test]
 fn test_minimal_spec() {
     let spec = ChainSpec::minimal();
-    assert_eq!(spec.preset_name(), "minimal");
     assert_eq!(spec.slots_per_epoch(), 8);
     assert_eq!(spec.epochs_per_sync_committee_period(), 8);
     assert_eq!(spec.sync_committee_size(), 32);
@@ -247,7 +245,6 @@ fn test_chainspec_config_valid() {
     assert!(config.validate().is_ok());
 
     let spec = ChainSpec::try_from_config(config).unwrap();
-    assert_eq!(spec.preset_name(), "custom");
     assert_eq!(spec.genesis_time(), 1700000000);
     assert_eq!(spec.seconds_per_slot(), 12);
     assert_eq!(spec.slots_per_epoch(), 32);

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -134,15 +134,6 @@ fn test_fork_minimal_preset() {
     // is an edge case that doesn't occur in practice.
 }
 
-#[test]
-fn test_fork_ordering() {
-    // Ensure Fork enum ordering is correct for comparisons
-    assert!(Fork::Altair < Fork::Bellatrix);
-    assert!(Fork::Bellatrix < Fork::Capella);
-    assert!(Fork::Capella < Fork::Deneb);
-    assert!(Fork::Deneb < Fork::Electra);
-}
-
 // Generalized Index Tests
 #[test]
 fn test_gindex_altair_through_deneb() {

--- a/src/consensus/light_client_spec_tests.rs
+++ b/src/consensus/light_client_spec_tests.rs
@@ -28,14 +28,25 @@ fn electra_sync_via_processor() {
     run_processor_sync(LightClientSyncTest::minimal_electra());
 }
 
-/// Cross-fork: Deneb bootstrap, chain forks to Electra mid-sequence, with
-/// Deneb- and Electra-format updates interleaved. Passing without any store
-/// migration is the point — the store is fork-agnostic, and each update
-/// selects its own decode layout (by fork digest) and proof geometry (by
-/// attested slot), so pyspec's `upgrade_store` step is a pure checkpoint here.
 #[test]
 fn electra_fork_sync_via_processor() {
     run_processor_sync(LightClientSyncTest::minimal_deneb_electra_fork());
+}
+
+fn initialize_processor_from(sync_test: &LightClientSyncTest) -> LightClientProcessor {
+    let bootstrap = sync_test
+        .load_bootstrap()
+        .expect("Failed to load bootstrap");
+    let chain_spec = sync_test.chain_spec();
+
+    LightClientProcessor::new(
+        chain_spec,
+        bootstrap.header.clone(),
+        bootstrap.current_sync_committee,
+        &bootstrap.current_sync_committee_branch,
+        bootstrap.genesis_validators_root,
+    )
+    .expect("Failed to initialize LightClientProcessor")
 }
 
 /// Replay a fixture's steps, asserting each against the fixture.
@@ -62,22 +73,6 @@ fn run_processor_sync(sync_test: LightClientSyncTest) {
         processed > 0,
         "no process_update steps ran before the first force_update"
     );
-}
-
-fn initialize_processor_from(sync_test: &LightClientSyncTest) -> LightClientProcessor {
-    let bootstrap = sync_test
-        .load_bootstrap()
-        .expect("Failed to load bootstrap");
-    let chain_spec = sync_test.chain_spec();
-
-    LightClientProcessor::new(
-        chain_spec,
-        bootstrap.header.clone(),
-        bootstrap.current_sync_committee,
-        &bootstrap.current_sync_committee_branch,
-        bootstrap.genesis_validators_root,
-    )
-    .expect("Failed to initialize LightClientProcessor")
 }
 
 fn execute_process_update_step(

--- a/src/consensus/processor.rs
+++ b/src/consensus/processor.rs
@@ -311,7 +311,7 @@ mod tests {
         let bootstrap_slot = bootstrap.header.slot();
 
         let mut processor = LightClientProcessor::new(
-            chain_spec,
+            chain_spec.clone(),
             bootstrap.header.clone(),
             bootstrap.current_sync_committee.clone(),
             &bootstrap.current_sync_committee_branch,

--- a/src/consensus/sync_committee.rs
+++ b/src/consensus/sync_committee.rs
@@ -476,17 +476,20 @@ mod tests {
     #[test]
     fn test_domain_uses_fork_version_at_signature_slot_epoch() {
         use super::compute_sync_committee_domain_for_slot;
-        use crate::config::ChainSpec;
+        use crate::config::{ChainSpec, ChainSpecConfig};
 
         // Create custom ChainSpec with fork boundary at epoch 1
         // Fork A (Altair) at epoch 0, Fork B (Bellatrix) at epoch 1
-        let chain_spec = ChainSpec::for_test(
-            8,                        // slots_per_epoch
-            [0x00, 0x00, 0x00, 0x00], // altair_fork_version (Fork A)
-            [0x01, 0x00, 0x00, 0x00], // bellatrix_fork_version (Fork B)
-            0,                        // altair_fork_epoch
-            1,                        // bellatrix_fork_epoch
-        );
+        let chain_spec = ChainSpec::try_from_config(ChainSpecConfig {
+            slots_per_epoch: 8,
+            altair_fork_version: [0x00, 0x00, 0x00, 0x00], // Fork A
+            bellatrix_fork_version: [0x01, 0x00, 0x00, 0x00], // Fork B
+            altair_fork_epoch: 0,
+            bellatrix_fork_epoch: 1,
+            // later forks stay inactive (u64::MAX in the minimal preset)
+            ..ChainSpecConfig::minimal()
+        })
+        .expect("valid fork-boundary schedule");
 
         let genesis_validators_root = [0xABu8; 32];
 


### PR DESCRIPTION
Closes #110. A commit-per-decision scrutiny pass over `src/config.rs`, driven by a call-site census and four recurring principles (cut what nothing consumes; the add-later/remove-later semver asymmetry breaks ties; the public boundary + orphan rule flips the default for durable conveniences; say each fact once, at its home).

## Commits

- **`6bb90c0`** — top-down reorder (ChainSpec ahead of ChainSpecConfig), `for_test` side-door removed (its one call site now goes through the public `try_from_config` gate), doc example modernized to preset-plus-overrides.
- **`f63a561`** — spec-test helper reorder + doc trim.
- **`e91a6ec`** — `preset_name` machinery deleted (zero production callers; three tautological assertions with it).
- **`badafeb`** — `fork_at_epoch`/`fork_at_slot` privatized: the engine asks for consequences (gindex, domain version), never "which fork?".
- **`fbf6c5c`** — five unconsumed getters deleted (trio + period-boundary pair); child-module tests read private fields directly; `timestamp_to_slot`'s pre-genesis 0 documented as fail-closed (bad clocks reject more, never accept more).
- **`37b8f33`** — config.rs reordered by containment (Fork → ChainSpec → ForkSchedule → ForkParams → ChainSpecConfig); per-variant fork commentary moved to a table in `src/README.md`.
- **`94297e3`** — untraced derives cut: Fork loses `PartialOrd/Ord/Hash` (only consumer was a test asserting the derive's own output), schedule types lose `PartialEq/Eq`.
- **`30711f0`** — `Copy` dropped from `ChainSpec` + schedule internals: unconsumed affordance (the one implicit copy was a test, now an explicit clone) and a fragile forever-promise on a struct designed to grow. `Debug + Clone` stay (public type, orphan rule, durable promises). `ChainSpecConfig` keeps `Copy` — the loader consumes it.
- **`05ed5d7`** — redundant `non_exhaustive` off `ChainSpec` (privacy already prevents what it forbids); kept on `Fork`, where it makes future fork variants non-breaking downstream.
- **`ef3721c`** — no-op `#[inline]` hints off the `pub(crate)` gindex selectors.

## Net effect

`ChainSpec`'s public surface is now exactly what has consumers: `mainnet`/`minimal`/`try_from_config` + `slots_per_epoch`, `sync_committee_size`, `slots_per_sync_committee_period`. Every remaining derive and attribute has a traceable consumer or a stated API story. ~180 lines lighter.

## Also riding along

Uncommitted on the branch (deliberately excluded from this PR's commits): the two `todo!()` transition-config stubs in `test_utils/fork.rs` — that's #106 slice one, next up after this merges.

Tests: 50 unit + 6 integration + doc-tests green throughout; clippy `-D warnings` clean apart from the two known stub warnings; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)