### PR TITLE
feat: fork_transition + digest transcription table (#112)

### DIFF
--- a/src/consensus/light_client_spec_tests.rs
+++ b/src/consensus/light_client_spec_tests.rs
@@ -30,7 +30,6 @@ fn electra_sync_via_processor() {
 }
 
 #[test]
-#[ignore = "fork_transition body pending (#112); un-ignore when it lands"]
 fn electra_fork_sync_via_processor() {
     run_processor_sync(SyncTestCase::fork_transition(Fork::Deneb, Fork::Electra));
 }

--- a/src/test_utils/fork.rs
+++ b/src/test_utils/fork.rs
@@ -1,5 +1,4 @@
 use crate::config::{ChainSpecConfig, Fork};
-use crate::types::primitives::Root;
 use std::path::{Path, PathBuf};
 
 pub(crate) fn fork_dir(fork: Fork) -> &'static str {
@@ -12,19 +11,6 @@ pub(crate) fn fork_dir(fork: Fork) -> &'static str {
     }
 }
 
-pub(crate) fn case_path(fork_dir: &str, case: &str) -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR")).join(format!(
-        "tests/fixtures/minimal/{fork_dir}/light_client/sync/{case}"
-    ))
-}
-
-fn _set_fork_epoch() {
-    todo!()
-}
-
-/// Fork-activation epochs are overridden so `fork` and its ancestors
-/// are active from genesis — the chain the single-fork fixtures were
-/// generated on.
 pub(crate) fn single_fork_config(fork: Fork) -> ChainSpecConfig {
     // Altair active at genesis: the LC floor
     let mut config = ChainSpecConfig::minimal();
@@ -45,52 +31,25 @@ pub(crate) fn single_fork_config(fork: Fork) -> ChainSpecConfig {
     config
 }
 
-/// Resolve a fixture fork digest (`fork_data_root[..4]`, per the consensus
-/// spec's `compute_fork_digest`) to the fork it identifies, by computing the
-/// digest of every fork active in `config` and matching.
-pub(crate) fn fork_for_digest(
-    digest: [u8; 4],
-    config: &ChainSpecConfig,
-    genesis_validators_root: Root,
-) -> Option<Fork> {
-    let candidates = [
-        (
-            Fork::Altair,
-            config.altair_fork_version,
-            config.altair_fork_epoch,
-        ),
-        (
-            Fork::Bellatrix,
-            config.bellatrix_fork_version,
-            config.bellatrix_fork_epoch,
-        ),
-        (
-            Fork::Capella,
-            config.capella_fork_version,
-            config.capella_fork_epoch,
-        ),
-        (
-            Fork::Deneb,
-            config.deneb_fork_version,
-            config.deneb_fork_epoch,
-        ),
-        (
-            Fork::Electra,
-            config.electra_fork_version,
-            config.electra_fork_epoch,
-        ),
-    ];
-    candidates
-        .into_iter()
-        .filter(|(_, _, epoch)| *epoch != u64::MAX) // inactive forks have no digest on this chain
-        .find(|(_, version, _)| {
-            let root = crate::consensus::sync_committee::compute_fork_data_root(
-                *version,
-                genesis_validators_root,
-            );
-            root[0..4] == digest
-        })
-        .map(|(fork, _, _)| fork)
+pub(crate) fn transition_config(from: Fork, to: Fork) -> ChainSpecConfig {
+    let mut config = single_fork_config(from);
+    let epoch = 3; // Epoch transitions are hardcoded in fixtures
+
+    match to {
+        Fork::Altair => config.altair_fork_epoch = epoch,
+        Fork::Bellatrix => config.bellatrix_fork_epoch = epoch,
+        Fork::Capella => config.capella_fork_epoch = epoch,
+        Fork::Deneb => config.deneb_fork_epoch = epoch,
+        Fork::Electra => config.electra_fork_epoch = epoch,
+    }
+
+    config
+}
+
+pub(crate) fn case_path(fork_dir: &str, case: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(format!(
+        "tests/fixtures/minimal/{fork_dir}/light_client/sync/{case}"
+    ))
 }
 
 #[cfg(test)]
@@ -223,5 +182,14 @@ mod tests {
             let yaml = load_case_config_yaml(fork_dir(fork), "light_client_sync");
             assert_schedule_matches(fork_dir(fork), &cfg, &yaml);
         }
+    }
+
+    /// Same drift guard for the transition schedules (currently: Deneb at
+    /// epoch 0, Electra activating at epoch 3).
+    #[test]
+    fn transition_schedule_matches_vendored_config_yaml() {
+        let cfg = super::transition_config(Fork::Deneb, Fork::Electra);
+        let yaml = load_case_config_yaml("deneb", "electra_fork");
+        assert_schedule_matches("deneb/electra_fork", &cfg, &yaml);
     }
 }

--- a/src/test_utils/loader.rs
+++ b/src/test_utils/loader.rs
@@ -1,4 +1,4 @@
-use super::fork::{case_path, fork_dir, fork_for_digest, single_fork_config};
+use super::fork::{case_path, fork_dir, single_fork_config, transition_config};
 use super::steps::{TestMeta, TestStep};
 use super::TestUtilsResult;
 use crate::config::{ChainSpec, ChainSpecConfig, Fork};
@@ -8,11 +8,11 @@ use std::path::{Path, PathBuf};
 
 pub struct SyncTestCase {
     case_dir: PathBuf,
-    config: ChainSpecConfig,
     meta: TestMeta,
     spec: ChainSpec,
 }
 
+/// Public constructors exist for each type of test case supported.
 impl SyncTestCase {
     pub fn light_client_sync(fork: Fork) -> Self {
         let fork_dir = fork_dir(fork);
@@ -22,10 +22,13 @@ impl SyncTestCase {
         )
     }
 
-    // TODO(#112): implement — schedule from `transition_config(from, to)`,
-    // case dir from `{fork_dir(to)}_fork` under `fork_dir(from)`.
-    pub fn fork_transition(_from: Fork, _to: Fork) -> Self {
-        todo!()
+    pub fn fork_transition(from: Fork, to: Fork) -> Self {
+        let from_dir = fork_dir(from);
+        let to_dir = fork_dir(to);
+        Self::open(
+            case_path(from_dir, &format!("{to_dir}_fork")),
+            transition_config(from, to),
+        )
     }
 
     fn open(case_dir: PathBuf, config: ChainSpecConfig) -> Self {
@@ -35,29 +38,22 @@ impl SyncTestCase {
         let spec = ChainSpec::try_from_config(config).expect("case chain schedule is valid");
         Self {
             case_dir,
-            config,
             meta,
             spec,
         }
     }
 
-    pub fn chain_spec(&self) -> &ChainSpec {
-        &self.spec
-    }
-
-    /// Resolve a fixture fork digest against this test's chain schedule.
-    fn resolve_fork(&self, digest: [u8; 4]) -> TestUtilsResult<Fork> {
-        fork_for_digest(digest, &self.config, self.meta.genesis_validators_root).ok_or_else(|| {
-            format!(
-                "no active fork in this case's schedule matches digest 0x{}",
-                hex::encode(digest)
-            )
-            .into()
-        })
+    pub fn load_steps(&self) -> TestUtilsResult<Vec<TestStep>> {
+        let steps_path = self.case_dir.join("steps.yaml");
+        let steps_contents = fs::read_to_string(&steps_path)?;
+        let steps: Vec<TestStep> = serde_yaml::with::singleton_map_recursive::deserialize(
+            serde_yaml::Deserializer::from_str(&steps_contents),
+        )?;
+        Ok(steps)
     }
 
     pub fn load_bootstrap(&self) -> TestUtilsResult<LightClientBootstrap> {
-        let fork = self.resolve_fork(self.meta.bootstrap_fork_digest)?;
+        let fork = Self::resolve_fork(self.meta.bootstrap_fork_digest)?;
         let bytes = snappy_decompress(&self.case_dir.join("bootstrap.ssz_snappy"))?;
         // Drive the public decode path (dogfoods `from_ssz`); snappy framing is
         // a fixture concern, so it stays here — the beacon API serves raw SSZ.
@@ -74,7 +70,7 @@ impl SyncTestCase {
         name: &str,
         fork_digest: [u8; 4],
     ) -> TestUtilsResult<LightClientUpdate> {
-        let fork = self.resolve_fork(fork_digest)?;
+        let fork = Self::resolve_fork(fork_digest)?;
         let bytes = snappy_decompress(&self.case_dir.join(format!("{name}.ssz_snappy")))?;
         Ok(LightClientUpdate::from_ssz(
             &bytes,
@@ -83,13 +79,23 @@ impl SyncTestCase {
         )?)
     }
 
-    pub fn load_steps(&self) -> TestUtilsResult<Vec<TestStep>> {
-        let steps_path = self.case_dir.join("steps.yaml");
-        let steps_contents = fs::read_to_string(&steps_path)?;
-        let steps: Vec<TestStep> = serde_yaml::with::singleton_map_recursive::deserialize(
-            serde_yaml::Deserializer::from_str(&steps_contents),
-        )?;
-        Ok(steps)
+    fn resolve_fork(digest: [u8; 4]) -> TestUtilsResult<Fork> {
+        match digest {
+            [0x15, 0xcf, 0xa0, 0xa7] => Ok(Fork::Altair),
+            [0x79, 0x0e, 0x5b, 0x44] => Ok(Fork::Bellatrix),
+            [0x85, 0x68, 0x42, 0xbe] => Ok(Fork::Capella),
+            [0x0c, 0xbc, 0xe9, 0x01] => Ok(Fork::Deneb),
+            [0x9a, 0xcb, 0x23, 0x0d] => Ok(Fork::Electra),
+            _ => Err(format!(
+                "no known minimal-preset fork digest matches 0x{}",
+                hex::encode(digest)
+            )
+            .into()),
+        }
+    }
+
+    pub fn chain_spec(&self) -> &ChainSpec {
+        &self.spec
     }
 }
 

--- a/tests/light_client_sync.rs
+++ b/tests/light_client_sync.rs
@@ -28,17 +28,11 @@ fn electra_sync_via_public_api() {
     run_public_api_sync(SyncTestCase::light_client_sync(Fork::Electra));
 }
 
-/// Cross-fork: Deneb bootstrap, chain forks to Electra mid-sequence, with
-/// Deneb- and Electra-format updates interleaved. The store needs no
-/// migration; pyspec's `upgrade_store` step is asserted as a pure checkpoint.
 #[test]
-#[ignore = "fork_transition body pending (#112); un-ignore when it lands"]
 fn electra_fork_sync_via_public_api() {
     run_public_api_sync(SyncTestCase::fork_transition(Fork::Deneb, Fork::Electra));
 }
 
-/// Replay the fixture's `process_update` steps through the public `LightClient`
-/// API; the fork is determined by `sync_test`.
 fn run_public_api_sync(sync_test: SyncTestCase) {
     let bootstrap = sync_test
         .load_bootstrap()


### PR DESCRIPTION
Completes #112's implementation item and simplifies digest resolution, restoring the two cross-fork replays #113 parked.

## fork_transition

- `transition_config(from, to)` = `single_fork_config(from)` + destination at epoch 3 — **evidence-backed**: all three single-boundary cases (`capella_fork`, `deneb_fork`, `electra_fork`) activate their destination at 3 per their own `config.yaml`s; multi-hop second activations differ (4, 5) and are out of this producer's domain.
- `SyncTestCase::fork_transition(from, to)` composes the case dir (`{fork_dir(to)}_fork` under `fork_dir(from)`) with that schedule through `open`'s validation gate.
- Both `electra_fork` replays un-ignored; transition drift guard restored.

## Digest table

Minimal-preset digests are constants (one shared genesis root across all pyspec minimal cases), so resolution is now a five-arm transcription table in `resolve_fork` — unknown digests fail loudly, naming the bytes. Cascade: `fork_for_digest` deleted; the `config` field leaves `SyncTestCase` (the table was its last consumer); `compute_fork_data_root` back to private — **the harness no longer touches production crypto**. `ForkData` correctness remains covered by its strongest checks: every replay's BLS verification (signatures made under true spec domains) and the sync_committee domain unit tests.

Tests: 50 + 6 + doc-tests green; clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)