### PR TITLE
refactor: processor scrutiny — wrapper inlining, test verdicts, docs catch-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let update = LightClientUpdate::from_ssz(&update_bytes, Fork::Capella, spec.sync_committee_size())?;
     client.process_update(update)?;
 
-    println!("Finalized slot: {}", client.finalized_header().slot);
+    println!("Finalized slot: {}", client.finalized_beacon_block_header().slot);
     Ok(())
 }
 ```
@@ -102,8 +102,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 **API Notes:**
 - Injectable time is available: If you want to supply your own notion of time (tests, embedded devices, custom clocks), use `process_update_at_slot(update, current_slot)`
-- Getters: `finalized_header()`, `optimistic_header()`, `current_sync_committee()`,
-  `next_sync_committee()`, `current_period()`, `chain_spec()`
+- Getters: `finalized_beacon_block_header()`, `optimistic_beacon_block_header()`,
+  `current_sync_committee()`, `next_sync_committee()`,
+  `current_sync_committee_period()`, `chain_spec()`
 
 **Custom/Devnet Configuration:**
 For local testnets or devnets, use `ChainSpecConfig` with `ChainSpec::try_from_config()`. See the rustdoc on `ChainSpecConfig` for usage examples.

--- a/src/consensus/README.md
+++ b/src/consensus/README.md
@@ -22,7 +22,7 @@ LightClient::new(spec, bootstrap)
         ▼
 LightClientProcessor::new(spec, header, committee, branch, genesis_root)
         │
-        ├─► merkle::verify_bootstrap_sync_committee
+        ├─► merkle::verify_merkle_proof
         │       proves committee is within the bootstrap header.state_root
         │
         └─► LightClientStore::new(header, committee, genesis_root)
@@ -37,7 +37,10 @@ LightClient::process_update(update)
 LightClientProcessor::process_update_at_slot(update, current_slot)
     │
     ├─[1]─► validate_light_client_update
-    │         • validate_basic: signature_slot > attested.slot, supermajority
+    │         • signature_slot > attested.slot, supermajority participation
+    │         • merkle::verify_light_client_header on attested (and finalized,
+    │           if present): execution payload inclusion in the beacon body
+    │           (Capella+; header-local, no signatures)
     │         • signature_slot <= current_slot
     │
     ├─[2]─► verify_update_signature  (&self, no mutation)
@@ -58,7 +61,7 @@ LightClientProcessor::process_update_at_slot(update, current_slot)
               │  store_period = store.finalized_sync_committee_period(spec)
               │
               ├─ if update has finalized_header with newer slot:
-              │    ► merkle::verify_finality_branch
+              │    ► merkle::verify_merkle_proof (finality branch → attested state_root)
               │    ► store.finalized_header = finalized_header
               │
               ├─ ROTATION: if period(update.finalized_header) == store_period + 1
@@ -69,10 +72,10 @@ LightClientProcessor::process_update_at_slot(update, current_slot)
               │       update, finalized_period, next_known, spec)
               │    guards: has committee data, next not already known,
               │            attested period == finalized period
-              │    ► merkle::verify_next_sync_committee
+              │    ► merkle::verify_merkle_proof (committee branch → attested state_root)
               │    ► store.next_sync_committee = Some(verified_committee)
               │
-              └─ update optimistic header, participation tracking
+              └─ update optimistic header if attested slot is newer
 ```
 
 **Note:** BLS signature verification answers one thing - did a supermajority of the sync committee we already trust actually sign this new header?
@@ -212,7 +215,6 @@ A *spec test* uses official Ethereum consensus fixtures — independent of scope
 Fixtures appear at **unit** scope too, not just in the replays:
 
 - `bls.rs::spec_tests` — official `fast_aggregate_verify` vectors (sync-committee verification is same-message aggregate, so that's the only production BLS entry point). They pin down *our* `bls.rs` adapter — DST, infinity handling, parameter marshaling — including the negative cases (tampered signatures, wrong pubkey sets) that the honest-path fixture replays never reach.
-- `merkle.rs::test_sync_committee_root_against_spec_fixture` — one sync-committee root + branch, checked against a bootstrap fixture.
 
 The BLS vectors are vendored under `tests/fixtures/general/phase0/bls` (the
 fixtures tree mirrors the upstream `consensus-spec-tests` layout).
@@ -230,9 +232,9 @@ consensus tests only consume the typed objects it returns.
 |---|---|---|
 | End-to-end spec sync | `consensus/light_client_spec_tests.rs` | Altair–Electra replays + every fork transition + per-fork behavioral cases; full force-update path remains `#[ignore]` |
 | BLS spec vectors | `consensus/bls.rs::spec_tests` | Official Ethereum BLS test vectors exercising the production `fast_aggregate_verify` path — including the negative cases (tampered signatures, infinity pubkeys) |
-| Merkle verification | `consensus/merkle.rs::tests` | Branch validation, sync committee root, spec fixture root match |
+| Merkle verification | `consensus/merkle.rs::tests` | Wrong-root rejection and malformed-branch `Err` paths — the false-*acceptance* failures the valid-only replays can never detect |
 | Committee guards | `consensus/sync_committee.rs::tests` | `Err` paths the valid-only fixtures never produce: unservable signature periods, next-committee learning guard |
-| Rotation drift | `consensus/processor.rs::tests` | Store period correctness after rotation (finalized-derived period remains consistent) |
+| Update validation guards | `consensus/processor.rs::tests` | `Err` paths the valid-only fixtures never produce: minority participation, signature-slot ordering |
 | Public API | `tests/light_client_sync.rs` | Full replays through the public `LightClient`; `UpdateOutcome` contract |
 | Supermajority threshold | `types/consensus/committee.rs::tests` | Exact 2/3 participation boundary |
 | ChainSpec | `chain_spec/tests.rs` | `ChainSpecConfig` validation `Err` paths (the custom-config contract); `timestamp_to_slot` (wall-clock path the replays never touch) |

--- a/src/consensus/light_client_spec_tests.rs
+++ b/src/consensus/light_client_spec_tests.rs
@@ -184,7 +184,7 @@ fn execute_process_update_step(
 fn assert_state_checks(step_num: usize, checks: &StateChecks, processor: &LightClientProcessor) {
     if let Some(expected) = &checks.finalized_header {
         assert!(
-            expected.matches(processor.finalized_header()),
+            expected.matches(processor.finalized_beacon_block_header()),
             "step {}: finalized header mismatch (expected slot {})",
             step_num,
             expected.slot,
@@ -201,7 +201,7 @@ fn assert_state_checks(step_num: usize, checks: &StateChecks, processor: &LightC
 
     if let Some(expected) = &checks.optimistic_header {
         assert!(
-            expected.matches(processor.optimistic_header()),
+            expected.matches(processor.optimistic_beacon_block_header()),
             "step {}: optimistic header mismatch (expected slot {})",
             step_num,
             expected.slot,

--- a/src/consensus/merkle.rs
+++ b/src/consensus/merkle.rs
@@ -2,54 +2,33 @@ use crate::error::{Error, Result};
 use crate::types::consensus::LightClientHeader;
 use crate::types::primitives::Root;
 
-pub(crate) fn validate_light_client_header(header: &LightClientHeader) -> Result<()> {
+const EXECUTION_PAYLOAD_GINDEX: u64 = 25;
+
+pub(crate) fn verify_light_client_header(header: &LightClientHeader) -> Result<()> {
     match header {
         LightClientHeader::Altair(_) | LightClientHeader::Bellatrix(_) => Ok(()),
-        LightClientHeader::Capella(h) => {
-            let execution_root = h.execution.hash_tree_root();
-            verify_execution_payload_inclusion(
-                &execution_root,
-                &h.execution_branch,
-                &h.beacon.body_root,
-            )
-        }
-        LightClientHeader::Deneb(h) => {
-            let execution_root = h.execution.hash_tree_root();
-            verify_execution_payload_inclusion(
-                &execution_root,
-                &h.execution_branch,
-                &h.beacon.body_root,
-            )
-        }
-        LightClientHeader::Electra(h) => {
-            let execution_root = h.execution.hash_tree_root();
-            verify_execution_payload_inclusion(
-                &execution_root,
-                &h.execution_branch,
-                &h.beacon.body_root,
-            )
-        }
+        LightClientHeader::Capella(h) => verify_merkle_proof(
+            &h.execution.hash_tree_root(),
+            &h.execution_branch,
+            EXECUTION_PAYLOAD_GINDEX,
+            &h.beacon.body_root,
+        ),
+        LightClientHeader::Deneb(h) => verify_merkle_proof(
+            &h.execution.hash_tree_root(),
+            &h.execution_branch,
+            EXECUTION_PAYLOAD_GINDEX,
+            &h.beacon.body_root,
+        ),
+        LightClientHeader::Electra(h) => verify_merkle_proof(
+            &h.execution.hash_tree_root(),
+            &h.execution_branch,
+            EXECUTION_PAYLOAD_GINDEX,
+            &h.beacon.body_root,
+        ),
     }
 }
 
-/// Constant for forks Capella -> Electra
-const EXECUTION_PAYLOAD_GINDEX: u64 = 25;
-
-pub(crate) fn verify_execution_payload_inclusion(
-    execution_root: &Root,
-    execution_branch: &[Root],
-    body_root: &Root,
-) -> Result<()> {
-    verify_merkle_branch(
-        execution_root,
-        execution_branch,
-        EXECUTION_PAYLOAD_GINDEX,
-        body_root,
-    )
-}
-
-// TODO: Rename to verify_merkle_proof
-pub(crate) fn verify_merkle_branch(
+pub(crate) fn verify_merkle_proof(
     leaf: &Root,
     branch: &[Root],
     gindex: u64,
@@ -65,16 +44,13 @@ pub(crate) fn verify_merkle_branch(
 }
 
 fn is_valid_merkle_branch(leaf: &Root, branch: &[Root], gindex: u64, root: &Root) -> Result<bool> {
-    if gindex == 0 {
-        return Err(Error::InvalidInput("gindex cannot be 0".to_string()));
-    }
-
     if gindex == 1 {
         return Ok(branch.is_empty() && leaf == root);
     }
 
-    // depth = floor(log2(gindex)) = 63 - leading_zeros
-    let expected_depth = 63u32 - gindex.leading_zeros();
+    let expected_depth = gindex
+        .checked_ilog2()
+        .ok_or_else(|| Error::InvalidInput("gindex cannot be 0".to_string()))?;
 
     if branch.len() != expected_depth as usize {
         return Err(Error::InvalidInput(format!(
@@ -111,6 +87,7 @@ fn hash_pair(left: &Root, right: &Root) -> Root {
     ethereum_hashing::hash32_concat(left, right)
 }
 
+// TODO: Are these unit tests necessary?
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/consensus/merkle.rs
+++ b/src/consensus/merkle.rs
@@ -4,6 +4,7 @@ use crate::types::primitives::Root;
 
 const EXECUTION_PAYLOAD_GINDEX: u64 = 25;
 
+// TODO: Rename... this function name sounds like it's checking the sync committee's signature over a light client's beacon block header.
 pub(crate) fn verify_light_client_header(header: &LightClientHeader) -> Result<()> {
     match header {
         LightClientHeader::Altair(_) | LightClientHeader::Bellatrix(_) => Ok(()),

--- a/src/consensus/merkle.rs
+++ b/src/consensus/merkle.rs
@@ -2,9 +2,10 @@ use crate::error::{Error, Result};
 use crate::types::consensus::LightClientHeader;
 use crate::types::primitives::Root;
 
+/// execution_payload's position in BeaconBlockBody. Unchanged Capella through Fulu.
 const EXECUTION_PAYLOAD_GINDEX: u64 = 25;
 
-// TODO: Rename... this function name sounds like it's checking the sync committee's signature over a light client's beacon block header.
+/// Proves header-internal consistency. No signature checks involved
 pub(crate) fn verify_light_client_header(header: &LightClientHeader) -> Result<()> {
     match header {
         LightClientHeader::Altair(_) | LightClientHeader::Bellatrix(_) => Ok(()),

--- a/src/consensus/merkle.rs
+++ b/src/consensus/merkle.rs
@@ -45,10 +45,6 @@ pub(crate) fn verify_merkle_proof(
 }
 
 fn is_valid_merkle_branch(leaf: &Root, branch: &[Root], gindex: u64, root: &Root) -> Result<bool> {
-    if gindex == 1 {
-        return Ok(branch.is_empty() && leaf == root);
-    }
-
     let expected_depth = gindex
         .checked_ilog2()
         .ok_or_else(|| Error::InvalidInput("gindex cannot be 0".to_string()))?;
@@ -88,11 +84,9 @@ fn hash_pair(left: &Root, right: &Root) -> Root {
     ethereum_hashing::hash32_concat(left, right)
 }
 
-// TODO: Are these unit tests necessary?
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::chain_spec::ChainSpec;
 
     #[test]
     fn test_merkle_branch_validation() {
@@ -123,32 +117,5 @@ mod tests {
 
         // Correct length, wrong root: reconstructs but doesn't match -> Ok(false).
         assert!(!is_valid_merkle_branch(&l, &[r], 2, &[9u8; 32]).unwrap());
-    }
-
-    #[test]
-    fn test_sync_committee_root_against_spec_fixture() {
-        use crate::test_utils::SyncTestCase;
-
-        let spec = ChainSpec::minimal();
-        let sync_test = SyncTestCase::light_client_sync(crate::Fork::Altair);
-        let bootstrap = sync_test
-            .load_bootstrap()
-            .expect("Failed to load bootstrap");
-
-        let computed_root = bootstrap.current_sync_committee.hash_tree_root();
-
-        let gindex = spec.current_sync_committee_gindex(bootstrap.header.slot());
-        let is_valid = is_valid_merkle_branch(
-            &computed_root,
-            &bootstrap.current_sync_committee_branch,
-            gindex,
-            bootstrap.header.state_root(),
-        )
-        .expect("Branch verification should not error");
-
-        assert!(
-            is_valid,
-            "Computed sync committee root should verify against spec fixture"
-        );
     }
 }

--- a/src/consensus/merkle.rs
+++ b/src/consensus/merkle.rs
@@ -1,55 +1,6 @@
-use crate::chain_spec::ChainSpec;
 use crate::error::{Error, Result};
-use crate::types::consensus::{LightClientHeader, SyncCommittee};
-use crate::types::primitives::{Root, Slot};
-
-pub(crate) fn verify_bootstrap_sync_committee(
-    sync_committee: &SyncCommittee,
-    sync_committee_branch: &[Root],
-    header_slot: Slot,
-    finalized_state_root: &Root,
-    spec: &ChainSpec,
-) -> Result<()> {
-    verify_merkle_branch(
-        &sync_committee.hash_tree_root(),
-        sync_committee_branch,
-        spec.current_sync_committee_gindex(header_slot),
-        finalized_state_root,
-        "current sync committee",
-    )
-}
-
-pub(crate) fn verify_next_sync_committee(
-    next_sync_committee: &SyncCommittee,
-    next_sync_committee_branch: &[Root],
-    attested_header_slot: Slot,
-    attested_state_root: &Root,
-    spec: &ChainSpec,
-) -> Result<()> {
-    verify_merkle_branch(
-        &next_sync_committee.hash_tree_root(),
-        next_sync_committee_branch,
-        spec.next_sync_committee_gindex(attested_header_slot),
-        attested_state_root,
-        "next sync committee",
-    )
-}
-
-pub(crate) fn verify_finality_branch(
-    finalized_header_root: &Root,
-    finality_branch: &[Root],
-    attested_header_slot: Slot,
-    attested_state_root: &Root,
-    spec: &ChainSpec,
-) -> Result<()> {
-    verify_merkle_branch(
-        finalized_header_root,
-        finality_branch,
-        spec.finalized_root_gindex(attested_header_slot),
-        attested_state_root,
-        "finality branch",
-    )
-}
+use crate::types::consensus::LightClientHeader;
+use crate::types::primitives::Root;
 
 pub(crate) fn validate_light_client_header(header: &LightClientHeader) -> Result<()> {
     match header {
@@ -94,22 +45,21 @@ pub(crate) fn verify_execution_payload_inclusion(
         execution_branch,
         EXECUTION_PAYLOAD_GINDEX,
         body_root,
-        "execution payload",
     )
 }
 
-fn verify_merkle_branch(
+// TODO: Rename to verify_merkle_proof
+pub(crate) fn verify_merkle_branch(
     leaf: &Root,
     branch: &[Root],
     gindex: u64,
     root: &Root,
-    what: &str,
 ) -> Result<()> {
     if is_valid_merkle_branch(leaf, branch, gindex, root)? {
         Ok(())
     } else {
         Err(Error::InvalidInput(format!(
-            "{what} merkle branch verification failed"
+            "merkle branch verification failed at gindex {gindex}"
         )))
     }
 }
@@ -164,6 +114,7 @@ fn hash_pair(left: &Root, right: &Root) -> Root {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::chain_spec::ChainSpec;
 
     #[test]
     fn test_merkle_branch_validation() {

--- a/src/consensus/processor.rs
+++ b/src/consensus/processor.rs
@@ -70,10 +70,23 @@ impl LightClientProcessor {
         update: &LightClientUpdate,
         current_slot: Slot,
     ) -> Result<()> {
-        // TODO: move `validate_basic`'s` logic inside this function. no need for wrapper
-        update.validate_basic(&self.store.current_sync_committee)?;
+        if update.signature_slot <= update.attested_header.slot() {
+            return Err(Error::InvalidInput(
+                "Signature slot must be after attested header slot".to_string(),
+            ));
+        }
+        if !update
+            .sync_aggregate
+            .has_supermajority(&self.store.current_sync_committee)
+        {
+            return Err(Error::InvalidInput(
+                "Insufficient sync committee participation".to_string(),
+            ));
+        }
 
         // Validate header-local consistency (execution branch for Capella+).
+        //
+        // TODO: Rename... this function name sounds like it's checking the sync committee's signature over a light client's beacon block header.
         verify_light_client_header(&update.attested_header)?;
         if let Some(ref finalized) = update.finalized {
             verify_light_client_header(&finalized.header)?;
@@ -219,7 +232,7 @@ mod tests {
     use super::*;
     use crate::chain_spec::Fork;
     use crate::test_utils::SyncTestCase;
-    use crate::types::consensus::AltairLightClientHeader;
+    use crate::types::consensus::{AltairLightClientHeader, SyncAggregate};
 
     fn create_test_beacon_header(slot: Slot) -> BeaconBlockHeader {
         BeaconBlockHeader {
@@ -229,6 +242,47 @@ mod tests {
             state_root: [2u8; 32],
             body_root: [3u8; 32],
         }
+    }
+
+    /// The two validate rules are Err paths the valid-only fixtures never
+    /// produce: minority participation (the safety threshold) and a signature
+    /// slot not strictly after the attested slot. Deleting either check leaves
+    /// every replay green.
+    #[test]
+    fn rejects_updates_failing_basic_validation() {
+        let mut processor = LightClientProcessor {
+            chain_spec: crate::chain_spec::ChainSpec::minimal(),
+            store: LightClientStore::new(
+                LightClientHeader::Altair(AltairLightClientHeader {
+                    beacon: create_test_beacon_header(1),
+                }),
+                SyncCommittee::from_parts(vec![[1u8; 48]; 32], [2u8; 48]).unwrap(),
+                [0u8; 32],
+            ),
+        };
+        let update = |bits, signature_slot| {
+            LightClientUpdate::new(
+                create_test_beacon_header(2),
+                SyncAggregate::new(bits, [0u8; 96]),
+                signature_slot,
+            )
+        };
+
+        // 10 of 32 participants — under the 2/3 supermajority.
+        let mut minority = vec![false; 32];
+        minority[..10].fill(true);
+        let err = processor
+            .process_update_at_slot(update(minority, 3), 4)
+            .err()
+            .unwrap();
+        assert!(err.to_string().contains("participation"), "got: {err}");
+
+        // signature_slot == attested slot — must be strictly after.
+        let err = processor
+            .process_update_at_slot(update(vec![true; 32], 2), 4)
+            .err()
+            .unwrap();
+        assert!(err.to_string().contains("Signature slot"), "got: {err}");
     }
 
     /// Drift-prevention regression test.

--- a/src/consensus/processor.rs
+++ b/src/consensus/processor.rs
@@ -1,5 +1,5 @@
 use crate::chain_spec::ChainSpec;
-use crate::consensus::merkle::{validate_light_client_header, verify_merkle_branch};
+use crate::consensus::merkle::{verify_light_client_header, verify_merkle_proof};
 use crate::consensus::store::LightClientStore;
 use crate::consensus::sync_committee;
 use crate::error::{Error, Result};
@@ -24,7 +24,7 @@ pub(crate) struct LightClientProcessor {
 }
 
 impl LightClientProcessor {
-    // TODO: Rename to bootstrap_sync_committee_*
+    // TODO: Rename to bootstrap_sync_committee_* / trusted_sync_committee_*
     pub(crate) fn new(
         chain_spec: ChainSpec,
         trusted_header: LightClientHeader,
@@ -32,7 +32,11 @@ impl LightClientProcessor {
         current_sync_committee_branch: &[Root],
         genesis_validators_root: Root,
     ) -> Result<Self> {
-        verify_merkle_branch(
+        // TODO: verify_light_client_header(&trusted_header)? — the spec's
+        // initialize_light_client_store asserts is_valid_light_client_header
+        // on the bootstrap header; we never check its execution payload
+        // consistency. See #128.
+        verify_merkle_proof(
             &current_sync_committee.hash_tree_root(),
             current_sync_committee_branch,
             chain_spec.current_sync_committee_gindex(trusted_header.slot()),
@@ -70,9 +74,9 @@ impl LightClientProcessor {
         update.validate_basic(&self.store.current_sync_committee)?;
 
         // Validate header-local consistency (execution branch for Capella+).
-        validate_light_client_header(&update.attested_header)?;
+        verify_light_client_header(&update.attested_header)?;
         if let Some(ref finalized) = update.finalized {
-            validate_light_client_header(&finalized.header)?;
+            verify_light_client_header(&finalized.header)?;
         }
 
         if update.signature_slot > current_slot {
@@ -123,7 +127,7 @@ impl LightClientProcessor {
 
         if let Some(ref finalized) = update.finalized {
             if finalized.header.slot() > self.store.finalized_header.slot() {
-                verify_merkle_branch(
+                verify_merkle_proof(
                     &finalized.header.beacon().hash_tree_root(),
                     &finalized.branch,
                     self.chain_spec

--- a/src/consensus/processor.rs
+++ b/src/consensus/processor.rs
@@ -86,7 +86,7 @@ impl LightClientProcessor {
 
         // Validate header-local consistency (execution branch for Capella+).
         //
-        // TODO: Rename... this function name sounds like it's checking the sync committee's signature over a light client's beacon block header.
+        // TODO: Rename... this function name sounds like it's checking the sync committee's signature over a light client's beacon block header, but it's checking execution payload's inclusion proof.
         verify_light_client_header(&update.attested_header)?;
         if let Some(ref finalized) = update.finalized {
             verify_light_client_header(&finalized.header)?;
@@ -188,24 +188,12 @@ impl LightClientProcessor {
         Ok(changes)
     }
 
-    // TODO: Rename to finalized_beacon_block_header
-    pub(crate) fn finalized_header(&self) -> &BeaconBlockHeader {
-        self.store.finalized_header.beacon()
-    }
-
-    #[cfg(test)]
-    pub(crate) fn finalized_light_client_header(&self) -> &LightClientHeader {
-        &self.store.finalized_header
-    }
-
-    // TODO: Rename to optimistic_beacon_block_header
-    pub(crate) fn optimistic_header(&self) -> &BeaconBlockHeader {
+    pub(crate) fn optimistic_beacon_block_header(&self) -> &BeaconBlockHeader {
         self.store.optimistic_header.beacon()
     }
 
-    #[cfg(test)]
-    pub(crate) fn optimistic_light_client_header(&self) -> &LightClientHeader {
-        &self.store.optimistic_header
+    pub(crate) fn finalized_beacon_block_header(&self) -> &BeaconBlockHeader {
+        self.store.finalized_header.beacon()
     }
 
     pub(crate) fn current_sync_committee(&self) -> &SyncCommittee {
@@ -216,13 +204,22 @@ impl LightClientProcessor {
         self.store.next_sync_committee.as_ref()
     }
 
-    // TODO: Rename to `current_sync_period`
-    pub(crate) fn current_period(&self) -> u64 {
+    pub(crate) fn current_sync_committee_period(&self) -> u64 {
         self.store.finalized_sync_committee_period(&self.chain_spec)
     }
 
     pub(crate) fn chain_spec(&self) -> &ChainSpec {
         &self.chain_spec
+    }
+
+    #[cfg(test)]
+    pub(crate) fn optimistic_light_client_header(&self) -> &LightClientHeader {
+        &self.store.optimistic_header
+    }
+
+    #[cfg(test)]
+    pub(crate) fn finalized_light_client_header(&self) -> &LightClientHeader {
+        &self.store.finalized_header
     }
 }
 
@@ -314,7 +311,7 @@ mod tests {
         .unwrap();
 
         let initial_period = chain_spec.slot_to_sync_committee_period(bootstrap_slot);
-        assert_eq!(processor.current_period(), initial_period);
+        assert_eq!(processor.current_sync_committee_period(), initial_period);
         assert!(processor.store.next_sync_committee.is_none());
 
         // Inject a distinguishable "next" committee directly on the store
@@ -364,7 +361,7 @@ mod tests {
         );
         // Period is derived from finalized header — automatically correct
         assert_eq!(
-            processor.current_period(),
+            processor.current_sync_committee_period(),
             initial_period + 1,
             "period should reflect the new finalized header"
         );

--- a/src/consensus/processor.rs
+++ b/src/consensus/processor.rs
@@ -24,7 +24,6 @@ pub(crate) struct LightClientProcessor {
 }
 
 impl LightClientProcessor {
-    // TODO: Rename to bootstrap_sync_committee_* / trusted_sync_committee_*
     pub(crate) fn new(
         chain_spec: ChainSpec,
         trusted_header: LightClientHeader,
@@ -84,9 +83,6 @@ impl LightClientProcessor {
             ));
         }
 
-        // Validate header-local consistency (execution branch for Capella+).
-        //
-        // TODO: Rename... this function name sounds like it's checking the sync committee's signature over a light client's beacon block header, but it's checking execution payload's inclusion proof.
         verify_light_client_header(&update.attested_header)?;
         if let Some(ref finalized) = update.finalized {
             verify_light_client_header(&finalized.header)?;

--- a/src/consensus/processor.rs
+++ b/src/consensus/processor.rs
@@ -167,8 +167,7 @@ impl LightClientProcessor {
             }
         }
 
-        // Learn next AFTER the finalized-header update + rotation, using the now-
-        // updated finalized period (see consensus/README data flow).
+        // Learn next AFTER the finalized-header update + rotation, using the now-updated finalized period (see consensus/README data flow).
         let finalized_period = self.store.finalized_sync_committee_period(&self.chain_spec);
         if let Some(verified) = sync_committee::learn_next_sync_committee(
             &update,
@@ -223,12 +222,9 @@ impl LightClientProcessor {
     }
 }
 
-// TODO: Do we need this test module at all? Processor is tested against spec tests
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::chain_spec::Fork;
-    use crate::test_utils::SyncTestCase;
     use crate::types::consensus::{AltairLightClientHeader, SyncAggregate};
 
     fn create_test_beacon_header(slot: Slot) -> BeaconBlockHeader {
@@ -241,10 +237,7 @@ mod tests {
         }
     }
 
-    /// The two validate rules are Err paths the valid-only fixtures never
-    /// produce: minority participation (the safety threshold) and a signature
-    /// slot not strictly after the attested slot. Deleting either check leaves
-    /// every replay green.
+    /// Sole detector: valid-only fixtures never exercise these Err arms.
     #[test]
     fn rejects_updates_failing_basic_validation() {
         let mut processor = LightClientProcessor {
@@ -280,90 +273,5 @@ mod tests {
             .err()
             .unwrap();
         assert!(err.to_string().contains("Signature slot"), "got: {err}");
-    }
-
-    /// Drift-prevention regression test.
-    ///
-    /// Verifies that after a simulated rotation:
-    ///   1. The store's current committee is what was previously next.
-    ///   2. The store's next committee is consumed (None).
-    ///   3. The processor's period (store-derived) matches the expected
-    ///      post-rotation period.
-    ///
-    /// Because there is no separate tracker, committee period is always
-    /// derived from `store.finalized_header.slot` — drift is structurally
-    /// impossible.
-    #[test]
-    fn test_store_period_correct_after_rotation() {
-        let bootstrap = SyncTestCase::light_client_sync(Fork::Altair)
-            .load_bootstrap()
-            .expect("Failed to load bootstrap");
-        let chain_spec = crate::chain_spec::ChainSpec::minimal();
-        let bootstrap_slot = bootstrap.header.slot();
-
-        let mut processor = LightClientProcessor::new(
-            chain_spec.clone(),
-            bootstrap.header.clone(),
-            bootstrap.current_sync_committee.clone(),
-            &bootstrap.current_sync_committee_branch,
-            bootstrap.genesis_validators_root,
-        )
-        .unwrap();
-
-        let initial_period = chain_spec.slot_to_sync_committee_period(bootstrap_slot);
-        assert_eq!(processor.current_sync_committee_period(), initial_period);
-        assert!(processor.store.next_sync_committee.is_none());
-
-        // Inject a distinguishable "next" committee directly on the store
-        let next = SyncCommittee::from_parts(vec![[0xAA; 48]; 32], [0xBB; 48]).unwrap();
-        processor.store.next_sync_committee = Some(next.clone());
-
-        // Store period is still initial_period (finalized header not yet updated)
-        let store_period = processor.store.finalized_sync_committee_period(&chain_spec);
-        assert_eq!(store_period, initial_period);
-
-        // Simulate an update whose finalized_header crosses into period+1
-        let next_period_slot = (initial_period + 1) * chain_spec.slots_per_sync_committee_period();
-        let finalized = create_test_beacon_header(next_period_slot);
-
-        // Exercise rotation directly (can't do full process_update because
-        // BLS/merkle proofs would fail with synthetic data). Uses the same
-        // `should_rotate` predicate as production.
-        if sync_committee::should_rotate(
-            finalized.slot,
-            store_period,
-            processor.store.next_sync_committee.is_some(),
-            &chain_spec,
-        ) {
-            processor.store.current_sync_committee = processor
-                .store
-                .next_sync_committee
-                .take()
-                .expect("should_rotate checked next is_some");
-            // Advance finalized header to match (as apply_light_client_update does)
-            processor.store.finalized_header =
-                LightClientHeader::Altair(AltairLightClientHeader { beacon: finalized });
-        }
-
-        // Assertions: store state is correct after rotation
-        assert_eq!(
-            processor
-                .store
-                .current_sync_committee
-                .aggregate_pubkey()
-                .as_ref(),
-            &[0xBB; 48],
-            "store current committee should be what was next"
-        );
-        assert!(
-            processor.store.next_sync_committee.is_none(),
-            "store next committee should be consumed"
-        );
-        // Period is derived from finalized header — automatically correct
-        assert_eq!(
-            processor.current_sync_committee_period(),
-            initial_period + 1,
-            "period should reflect the new finalized header"
-        );
     }
 }

--- a/src/consensus/processor.rs
+++ b/src/consensus/processor.rs
@@ -1,7 +1,5 @@
 use crate::chain_spec::ChainSpec;
-use crate::consensus::merkle::{
-    validate_light_client_header, verify_bootstrap_sync_committee, verify_finality_branch,
-};
+use crate::consensus::merkle::{validate_light_client_header, verify_merkle_branch};
 use crate::consensus::store::LightClientStore;
 use crate::consensus::sync_committee;
 use crate::error::{Error, Result};
@@ -11,12 +9,6 @@ use crate::types::consensus::{
 use crate::types::primitives::Root;
 use crate::types::primitives::Slot;
 
-#[derive(Debug)]
-pub(crate) struct LightClientProcessor {
-    chain_spec: ChainSpec,
-    store: LightClientStore,
-}
-
 #[derive(Default)]
 pub(crate) struct UpdateChanges {
     pub finalized_updated: bool,
@@ -25,7 +17,14 @@ pub(crate) struct UpdateChanges {
     pub next_committee_learned: bool,
 }
 
+#[derive(Debug)]
+pub(crate) struct LightClientProcessor {
+    chain_spec: ChainSpec,
+    store: LightClientStore,
+}
+
 impl LightClientProcessor {
+    // TODO: Rename to bootstrap_sync_committee_*
     pub(crate) fn new(
         chain_spec: ChainSpec,
         trusted_header: LightClientHeader,
@@ -33,12 +32,11 @@ impl LightClientProcessor {
         current_sync_committee_branch: &[Root],
         genesis_validators_root: Root,
     ) -> Result<Self> {
-        verify_bootstrap_sync_committee(
-            &current_sync_committee,
+        verify_merkle_branch(
+            &current_sync_committee.hash_tree_root(),
             current_sync_committee_branch,
-            trusted_header.slot(),
+            chain_spec.current_sync_committee_gindex(trusted_header.slot()),
             trusted_header.state_root(),
-            &chain_spec,
         )?;
 
         let store = LightClientStore::new(
@@ -68,6 +66,7 @@ impl LightClientProcessor {
         update: &LightClientUpdate,
         current_slot: Slot,
     ) -> Result<()> {
+        // TODO: move `validate_basic`'s` logic inside this function. no need for wrapper
         update.validate_basic(&self.store.current_sync_committee)?;
 
         // Validate header-local consistency (execution branch for Capella+).
@@ -124,13 +123,12 @@ impl LightClientProcessor {
 
         if let Some(ref finalized) = update.finalized {
             if finalized.header.slot() > self.store.finalized_header.slot() {
-                let finalized_header_root = finalized.header.beacon().hash_tree_root();
-                verify_finality_branch(
-                    &finalized_header_root,
+                verify_merkle_branch(
+                    &finalized.header.beacon().hash_tree_root(),
                     &finalized.branch,
-                    update.attested_header.slot(),
+                    self.chain_spec
+                        .finalized_root_gindex(update.attested_header.slot()),
                     update.attested_header.state_root(),
-                    &self.chain_spec,
                 )?;
 
                 self.store.finalized_header = finalized.header.clone();

--- a/src/consensus/sync_committee.rs
+++ b/src/consensus/sync_committee.rs
@@ -1,6 +1,6 @@
 use crate::chain_spec::ChainSpec;
 use crate::consensus::bls;
-use crate::consensus::merkle::verify_next_sync_committee;
+use crate::consensus::merkle::verify_merkle_branch;
 use crate::error::{Error, Result};
 use crate::types::consensus::{LightClientUpdate, SyncCommittee};
 use crate::types::primitives::{BLSSignature, Domain, ForkVersion, Root, Slot};
@@ -88,12 +88,11 @@ pub(crate) fn learn_next_sync_committee(
         )));
     }
 
-    verify_next_sync_committee(
-        &next.committee,
+    verify_merkle_branch(
+        &next.committee.hash_tree_root(),
         &next.branch,
-        update.attested_header.slot(),
+        chain_spec.next_sync_committee_gindex(update.attested_header.slot()),
         update.attested_header.state_root(),
-        chain_spec,
     )?;
 
     Ok(Some(next.committee.clone()))

--- a/src/consensus/sync_committee.rs
+++ b/src/consensus/sync_committee.rs
@@ -1,6 +1,6 @@
 use crate::chain_spec::ChainSpec;
 use crate::consensus::bls;
-use crate::consensus::merkle::verify_merkle_branch;
+use crate::consensus::merkle::verify_merkle_proof;
 use crate::error::{Error, Result};
 use crate::types::consensus::{LightClientUpdate, SyncCommittee};
 use crate::types::primitives::{BLSSignature, Domain, ForkVersion, Root, Slot};
@@ -88,7 +88,7 @@ pub(crate) fn learn_next_sync_committee(
         )));
     }
 
-    verify_merkle_branch(
+    verify_merkle_proof(
         &next.committee.hash_tree_root(),
         &next.branch,
         chain_spec.next_sync_committee_gindex(update.attested_header.slot()),

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -45,16 +45,15 @@ impl LightClient {
     }
 
     #[inline]
-    pub fn finalized_header(&self) -> &BeaconBlockHeader {
-        self.inner.finalized_header()
+    pub fn finalized_beacon_block_header(&self) -> &BeaconBlockHeader {
+        self.inner.finalized_beacon_block_header()
     }
 
     #[inline]
-    pub fn optimistic_header(&self) -> &BeaconBlockHeader {
-        self.inner.optimistic_header()
+    pub fn optimistic_beacon_block_header(&self) -> &BeaconBlockHeader {
+        self.inner.optimistic_beacon_block_header()
     }
 
-    /// The current period's sync committee.
     #[inline]
     pub fn current_sync_committee(&self) -> &SyncCommittee {
         self.inner.current_sync_committee()
@@ -66,10 +65,9 @@ impl LightClient {
         self.inner.next_sync_committee()
     }
 
-    /// The current sync committee period (derived from the finalized header).
     #[inline]
-    pub fn current_period(&self) -> u64 {
-        self.inner.current_period()
+    pub fn current_sync_committee_period(&self) -> u64 {
+        self.inner.current_sync_committee_period()
     }
 
     #[inline]
@@ -81,9 +79,12 @@ impl LightClient {
 impl std::fmt::Debug for LightClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LightClient")
-            .field("finalized_slot", &self.finalized_header().slot)
-            .field("optimistic_slot", &self.optimistic_header().slot)
-            .field("current_period", &self.current_period())
+            .field("finalized_slot", &self.finalized_beacon_block_header().slot)
+            .field(
+                "optimistic_slot",
+                &self.optimistic_beacon_block_header().slot,
+            )
+            .field("current_period", &self.current_sync_committee_period())
             .field("has_next_committee", &self.next_sync_committee().is_some())
             .finish()
     }

--- a/src/types/consensus/headers.rs
+++ b/src/types/consensus/headers.rs
@@ -59,6 +59,7 @@ impl LightClientHeader {
         }
     }
 
+    // TODO: should this be renamed to proposed_slot?  "slot" could read as proposed or sync committee signature slot.
     pub fn slot(&self) -> Slot {
         self.beacon().slot
     }

--- a/src/types/consensus/headers.rs
+++ b/src/types/consensus/headers.rs
@@ -59,7 +59,7 @@ impl LightClientHeader {
         }
     }
 
-    // TODO: should this be renamed to proposed_slot?  "slot" could read as proposed or sync committee signature slot.
+    /// Returns the slot the beacon block was proposed in, not the signature slot.
     pub fn slot(&self) -> Slot {
         self.beacon().slot
     }

--- a/src/types/consensus/messages.rs
+++ b/src/types/consensus/messages.rs
@@ -1,6 +1,6 @@
 use super::{LightClientHeader, SyncAggregate, SyncCommittee};
 use crate::chain_spec::Fork;
-use crate::error::{Error, Result};
+use crate::error::Result;
 use crate::types::primitives::{Root, Slot};
 
 #[cfg(test)]
@@ -14,18 +14,16 @@ pub struct LightClientUpdate {
     pub finalized: Option<FinalityUpdate>,
     pub next_sync_committee: Option<SyncCommitteeUpdate>,
     pub sync_aggregate: SyncAggregate,
-    /// Should be attested_header.slot + 1
+    /// Must be > attested_header.slot
     pub signature_slot: Slot,
 }
 
-/// A finalized header paired with the Merkle branch proving it in the attested state.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FinalityUpdate {
     pub header: LightClientHeader,
     pub branch: Vec<Root>,
 }
 
-/// A next sync committee paired with the Merkle branch proving it in the attested state.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SyncCommitteeUpdate {
     pub committee: SyncCommittee,
@@ -58,22 +56,6 @@ impl LightClientUpdate {
     pub fn with_next_sync_committee(mut self, committee: SyncCommittee, branch: Vec<Root>) -> Self {
         self.next_sync_committee = Some(SyncCommitteeUpdate { committee, branch });
         self
-    }
-
-    pub(crate) fn validate_basic(&self, sync_committee: &SyncCommittee) -> Result<()> {
-        if self.signature_slot <= self.attested_header.slot() {
-            return Err(Error::InvalidInput(
-                "Signature slot must be after attested header slot".to_string(),
-            ));
-        }
-
-        if !self.sync_aggregate.has_supermajority(sync_committee) {
-            return Err(Error::InvalidInput(
-                "Insufficient sync committee participation".to_string(),
-            ));
-        }
-
-        Ok(())
     }
 
     pub(crate) fn has_sync_committee_update(&self) -> bool {
@@ -116,33 +98,5 @@ impl LightClientBootstrap {
             current_sync_committee_branch,
             genesis_validators_root,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_light_client_update_validation() {
-        let attested_header = BeaconBlockHeader {
-            slot: 1000,
-            proposer_index: 42,
-            parent_root: [1u8; 32],
-            state_root: [2u8; 32],
-            body_root: [3u8; 32],
-        };
-        let sync_aggregate = SyncAggregate::new(vec![true; 32], [1u8; 96]);
-
-        let update = LightClientUpdate::new(
-            attested_header,
-            sync_aggregate,
-            1001, // signature_slot must be > attested_header.slot
-        );
-
-        let sync_committee = SyncCommittee::from_parts(vec![[1u8; 48]; 32], [2u8; 48]).unwrap();
-        assert!(update.validate_basic(&sync_committee).is_ok());
-        assert!(update.finalized.is_none());
-        assert!(!update.has_sync_committee_update());
     }
 }

--- a/tests/light_client_sync.rs
+++ b/tests/light_client_sync.rs
@@ -156,15 +156,15 @@ fn process_step(
         .load_update(&step.update, step.update_fork_digest)
         .expect("Failed to load update");
 
-    let before_finalized = client.finalized_header().slot;
-    let before_optimistic = client.optimistic_header().slot;
+    let before_finalized = client.finalized_beacon_block_header().slot;
+    let before_optimistic = client.optimistic_beacon_block_header().slot;
 
     let outcome: UpdateOutcome = client
         .process_update_at_slot(update, step.current_slot)
         .unwrap_or_else(|e| panic!("step {}: error processing update: {}", step_num, e));
 
-    let after_finalized = client.finalized_header().slot;
-    let after_optimistic = client.optimistic_header().slot;
+    let after_finalized = client.finalized_beacon_block_header().slot;
+    let after_optimistic = client.optimistic_beacon_block_header().slot;
 
     // UpdateOutcome must agree with observed state.
     if outcome.finalized_updated() {
@@ -190,7 +190,7 @@ fn process_step(
 fn assert_header_checks(client: &LightClient, checks: &StateChecks, step_num: usize) {
     if let Some(expected) = &checks.finalized_header {
         assert!(
-            expected.matches(client.finalized_header()),
+            expected.matches(client.finalized_beacon_block_header()),
             "step {}: finalized header mismatch (expected slot {})",
             step_num,
             expected.slot,
@@ -198,7 +198,7 @@ fn assert_header_checks(client: &LightClient, checks: &StateChecks, step_num: us
     }
     if let Some(expected) = &checks.optimistic_header {
         assert!(
-            expected.matches(client.optimistic_header()),
+            expected.matches(client.optimistic_beacon_block_header()),
             "step {}: optimistic header mismatch (expected slot {})",
             step_num,
             expected.slot,


### PR DESCRIPTION
Closes #127. The processor.rs pass, same razor as #123/#126: replays are the detector; indirection must earn its hop.

- **Wrapper inlining** (`bdf7fa6`): single-consumer merkle wrappers dissolved into their call sites; mismatch errors carry the gindex; merkle.rs no longer imports ChainSpec. Review caught a wrong slot feeding `finalized_root_gindex` → #128.
- **Merkle restructure** (`1d97344`): `verify_merkle_proof` / `verify_light_client_header` naming split, per-fork header arms, depth via `checked_ilog2()`.
- **validate_basic fold** (`c2d048a`): rules inlined into `validate_light_client_update` per spec shape; messages.rs is pure data again; condensed guard test for the two Err arms.
- **Accessor renames** (`b9f2594`): `finalized_beacon_block_header` / `optimistic_beacon_block_header` / `current_sync_committee_period`, propagated through the public facade.
- **Test verdicts by mutation-check** (`02cb7a7`): deleted the replay-shadowed rotation-drift and fixture-root tests; kept `test_merkle_branch_roundtrip` — with verification mutated to always-accept, the whole replay suite stays green, so its wrong-root assertion is the sole detector. Redundant `gindex==1` special case dropped.
- **Docs catch-up** (`42468bd`): consensus README data flow matches the inlined calls; naming TODOs resolved as doc comments (spec names kept); root README accessors fixed.

Deferred: fork-varying gindices as `const fn`s on `Fork` (#127 "Later" note); unconditional proof verification + bootstrap header validation (#128).

🤖 Generated with [Claude Code](https://claude.com/claude-code)