### PR TITLE
refactor: gindices move onto Fork

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -42,7 +42,10 @@ The `chain_spec` module is the single source of truth for **network parameters**
 
 This module owns two consensus-critical, fork-dependent lookups:
 - `fork_version_at_epoch` → the signing **domain** (sync-committee sig checks)
-- `*_gindex(slot)` → the Merkle **generalized indices** (proof checks)
+- `fork_at_slot` → which fork's rules apply; callers read fork-keyed constants
+  off the returned `Fork` itself — e.g. the Merkle **generalized indices**
+  (`fork.finalized_root_gindex()`), which are universal layout constants, not
+  network data
 
 **The module holds no verification behavior** — no SSZ, Merkle, or signature logic, only data and pure lookups. Verification lives in `consensus/`, parameterized by what `chain_spec` returns:
 > `chain_spec` module = inert, correctness-critical data + pure lookups

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -11,6 +11,29 @@ pub enum Fork {
     Electra,
 }
 
+impl Fork {
+    pub(crate) const fn current_sync_committee_gindex(&self) -> u64 {
+        match self {
+            Fork::Electra => 86,
+            _ => 54,
+        }
+    }
+
+    pub(crate) const fn next_sync_committee_gindex(&self) -> u64 {
+        match self {
+            Fork::Electra => 87,
+            _ => 55,
+        }
+    }
+
+    pub(crate) const fn finalized_root_gindex(&self) -> u64 {
+        match self {
+            Fork::Electra => 169,
+            _ => 105,
+        }
+    }
+}
+
 /// Defines network-specific constants.
 #[derive(Debug, Clone)]
 pub struct ChainSpec {
@@ -44,13 +67,28 @@ impl ChainSpec {
             slots_per_epoch: config.slots_per_epoch,
             epochs_per_sync_committee_period: config.epochs_per_sync_committee_period,
             sync_committee_size: config.sync_committee_size,
-            fork_schedule: ForkSchedule::new(
-                ForkParams::new(config.altair_fork_version, config.altair_fork_epoch),
-                ForkParams::new(config.bellatrix_fork_version, config.bellatrix_fork_epoch),
-                ForkParams::new(config.capella_fork_version, config.capella_fork_epoch),
-                ForkParams::new(config.deneb_fork_version, config.deneb_fork_epoch),
-                ForkParams::new(config.electra_fork_version, config.electra_fork_epoch),
-            ),
+            fork_schedule: ForkSchedule {
+                altair: ForkParams {
+                    version: config.altair_fork_version,
+                    epoch: config.altair_fork_epoch,
+                },
+                bellatrix: ForkParams {
+                    version: config.bellatrix_fork_version,
+                    epoch: config.bellatrix_fork_epoch,
+                },
+                capella: ForkParams {
+                    version: config.capella_fork_version,
+                    epoch: config.capella_fork_epoch,
+                },
+                deneb: ForkParams {
+                    version: config.deneb_fork_version,
+                    epoch: config.deneb_fork_epoch,
+                },
+                electra: ForkParams {
+                    version: config.electra_fork_version,
+                    epoch: config.electra_fork_epoch,
+                },
+            },
         }
     }
 
@@ -74,10 +112,7 @@ impl ChainSpec {
         self.slot_to_epoch(slot) / self.epochs_per_sync_committee_period
     }
 
-    /// Pre-genesis timestamps map to slot 0 — fail-closed: a wrong/early clock
-    /// lowers `current_slot`, and validation rejects updates with
-    /// `signature_slot > current_slot`, so a bad clock rejects more, never
-    /// accepts more.
+    /// Fail-closed: a wrong/early clock lowers `current_slot`, and validation rejects updates with `signature_slot > current_slot`, so a bad clock rejects more, never accepts more.
     pub(crate) fn timestamp_to_slot(&self, timestamp_secs: u64) -> u64 {
         if timestamp_secs >= self.genesis_time {
             (timestamp_secs - self.genesis_time) / self.seconds_per_slot
@@ -90,33 +125,12 @@ impl ChainSpec {
         self.fork_schedule.fork_at_epoch(epoch)
     }
 
-    const fn fork_at_slot(&self, slot: Slot) -> Fork {
+    pub(crate) const fn fork_at_slot(&self, slot: Slot) -> Fork {
         self.fork_at_epoch(slot / self.slots_per_epoch)
     }
 
     pub(crate) const fn fork_version_at_epoch(&self, epoch: u64) -> [u8; 4] {
         self.fork_schedule.version_at_epoch(epoch)
-    }
-
-    pub(crate) const fn current_sync_committee_gindex(&self, slot: Slot) -> u64 {
-        match self.fork_at_slot(slot) {
-            Fork::Electra => 86,
-            _ => 54,
-        }
-    }
-
-    pub(crate) const fn next_sync_committee_gindex(&self, slot: Slot) -> u64 {
-        match self.fork_at_slot(slot) {
-            Fork::Electra => 87,
-            _ => 55,
-        }
-    }
-
-    pub(crate) const fn finalized_root_gindex(&self, slot: Slot) -> u64 {
-        match self.fork_at_slot(slot) {
-            Fork::Electra => 169,
-            _ => 105,
-        }
     }
 }
 
@@ -130,30 +144,14 @@ pub(crate) struct ForkSchedule {
 }
 
 impl ForkSchedule {
-    pub(crate) const fn new(
-        altair: ForkParams,
-        bellatrix: ForkParams,
-        capella: ForkParams,
-        deneb: ForkParams,
-        electra: ForkParams,
-    ) -> Self {
-        Self {
-            altair,
-            bellatrix,
-            capella,
-            deneb,
-            electra,
-        }
-    }
-
     pub(crate) const fn fork_at_epoch(&self, epoch: u64) -> Fork {
-        if epoch >= self.electra.epoch() {
+        if epoch >= self.electra.epoch {
             Fork::Electra
-        } else if epoch >= self.deneb.epoch() {
+        } else if epoch >= self.deneb.epoch {
             Fork::Deneb
-        } else if epoch >= self.capella.epoch() {
+        } else if epoch >= self.capella.epoch {
             Fork::Capella
-        } else if epoch >= self.bellatrix.epoch() {
+        } else if epoch >= self.bellatrix.epoch {
             Fork::Bellatrix
         } else {
             Fork::Altair
@@ -162,11 +160,11 @@ impl ForkSchedule {
 
     pub(crate) const fn version_at_epoch(&self, epoch: u64) -> [u8; 4] {
         match self.fork_at_epoch(epoch) {
-            Fork::Altair => self.altair.version(),
-            Fork::Bellatrix => self.bellatrix.version(),
-            Fork::Capella => self.capella.version(),
-            Fork::Deneb => self.deneb.version(),
-            Fork::Electra => self.electra.version(),
+            Fork::Altair => self.altair.version,
+            Fork::Bellatrix => self.bellatrix.version,
+            Fork::Capella => self.capella.version,
+            Fork::Deneb => self.deneb.version,
+            Fork::Electra => self.electra.version,
         }
     }
 }
@@ -175,20 +173,6 @@ impl ForkSchedule {
 pub(crate) struct ForkParams {
     version: [u8; 4],
     epoch: u64,
-}
-
-impl ForkParams {
-    pub(crate) const fn new(version: [u8; 4], epoch: u64) -> Self {
-        Self { version, epoch }
-    }
-
-    pub(crate) const fn version(&self) -> [u8; 4] {
-        self.version
-    }
-
-    pub(crate) const fn epoch(&self) -> u64 {
-        self.epoch
-    }
 }
 
 /// Configurations for creating a [`ChainSpec`].

--- a/src/consensus/README.md
+++ b/src/consensus/README.md
@@ -165,7 +165,7 @@ Generalized indices for merkle proofs are fork-dependent (change at Electra):
 | `next_sync_committee` | 55 | 87 |
 | `finalized_checkpoint.root` | 105 | 169 |
 
-See `ChainSpec::current_sync_committee_gindex()` and siblings in `../chain_spec.rs`.
+See the `const fn` gindex methods on `Fork` in `../chain_spec.rs`.
 
 ## Fork Awareness
 
@@ -173,7 +173,8 @@ The engine implements fork-aware light client verification across all
 supported forks (Altair through Electra), including every fork boundary.
 `LightClientHeader` is a fork enum whose Capella+ variants carry the execution
 payload header and its inclusion branch; `ChainSpec` carries the full fork
-schedule and selects the generalized indices, which change at Electra.
+schedule and answers slot → `Fork`, and `Fork` itself carries the generalized
+indices, which change at Electra.
 
 Each supported fork was added by the same steps, which also remain for Fulu
 onward:

--- a/src/consensus/processor.rs
+++ b/src/consensus/processor.rs
@@ -38,7 +38,9 @@ impl LightClientProcessor {
         verify_merkle_proof(
             &current_sync_committee.hash_tree_root(),
             current_sync_committee_branch,
-            chain_spec.current_sync_committee_gindex(trusted_header.slot()),
+            chain_spec
+                .fork_at_slot(trusted_header.slot())
+                .current_sync_committee_gindex(),
             trusted_header.state_root(),
         )?;
 
@@ -140,7 +142,8 @@ impl LightClientProcessor {
                     &finalized.header.beacon().hash_tree_root(),
                     &finalized.branch,
                     self.chain_spec
-                        .finalized_root_gindex(update.attested_header.slot()),
+                        .fork_at_slot(update.attested_header.slot())
+                        .finalized_root_gindex(),
                     update.attested_header.state_root(),
                 )?;
 

--- a/src/consensus/sync_committee.rs
+++ b/src/consensus/sync_committee.rs
@@ -91,7 +91,9 @@ pub(crate) fn learn_next_sync_committee(
     verify_merkle_proof(
         &next.committee.hash_tree_root(),
         &next.branch,
-        chain_spec.next_sync_committee_gindex(update.attested_header.slot()),
+        chain_spec
+            .fork_at_slot(update.attested_header.slot())
+            .next_sync_committee_gindex(),
         update.attested_header.state_root(),
     )?;
 


### PR DESCRIPTION
The #127 "Later" item. Fork → gindex is a universal layout constant (identical on every network); slot → fork is the network-dependent half. Housing both on ChainSpec let the signature over-claim its dependencies.

- Gindices are now `const fn`s on `Fork` (`Fork::Electra.finalized_root_gindex() == 169`); call sites read as the two-step fact: `spec.fork_at_slot(slot).finalized_root_gindex()`.
- `ForkSchedule::new` dissolved — five same-typed positional params were a silent row-swap hazard (the #117 `BeaconBlockHeader::new` finding, times five). Construction is named struct literals in `from_config`.
- `ForkParams::new` + field accessors dissolved; all consumers are same-module, reading fields directly. `ForkParams` is a plain data row.
- `EXECUTION_PAYLOAD_GINDEX` deliberately stays a bare const in merkle.rs: it takes *nothing* because it depends on nothing — same taxonomy, third tier.
- READMEs follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)