### PR TITLE
refactor: verify_update_signature folds into validate, moves to sync_committee.rs

### DIFF
--- a/src/consensus/README.md
+++ b/src/consensus/README.md
@@ -36,27 +36,27 @@ LightClient::process_update(update)
     ▼
 LightClientProcessor::process_update_at_slot(update, current_slot)
     │
-    ├─[1]─► validate_light_client_update
-    │         • signature_slot > attested.slot, supermajority participation
+    ├─[1]─► validate_light_client_update  (&self, no mutation)
+    │         • supermajority participation
     │         • merkle::verify_light_client_header on attested (and finalized,
     │           if present): execution payload inclusion in the beacon body
     │           (Capella+; header-local, no signatures)
-    │         • signature_slot <= current_slot
-    │
-    ├─[2]─► verify_update_signature  (&self, no mutation)
+    │         • signature_slot > attested.slot, signature_slot <= current_slot
     │         │
-    │         ├─► sync_committee::committee_for_signature_slot(sig_slot,
-    │         │       store.finalized_header.slot,
-    │         │       &store.current_sync_committee, store.next_sync_committee.as_ref(),
-    │         │       spec)
-    │         │     selects current or next committee by period comparison
-    │         │
-    │         └─► sync_committee::verify_sync_aggregate(committee, sig_slot,
-    │                 header_root, bits, signature, genesis_root, spec)
-    │               domain = compute_sync_committee_domain_for_signature_slot(sig_slot, …)
-    │               bls::fast_aggregate_verify(participating_pubkeys, signing_root, sig)
+    │         └─► sync_committee::verify_update_signature  (last validation step)
+    │               │
+    │               ├─► committee_for_signature_slot(sig_slot,
+    │               │       store.finalized_header.slot,
+    │               │       &store.current_sync_committee, store.next_sync_committee.as_ref(),
+    │               │       spec)
+    │               │     selects current or next committee by period comparison
+    │               │
+    │               └─► verify_sync_aggregate(committee, sig_slot,
+    │                       header_root, bits, signature, genesis_root, spec)
+    │                     domain = compute_sync_committee_domain_for_signature_slot(sig_slot, …)
+    │                     bls::fast_aggregate_verify(participating_pubkeys, signing_root, sig)
     │
-    └─[3]─► apply_light_client_update  (&mut self)
+    └─[2]─► apply_light_client_update  (&mut self)
               │
               │  store_period = store.finalized_sync_committee_period(spec)
               │
@@ -237,7 +237,7 @@ consensus tests only consume the typed objects it returns.
 | Committee guards | `consensus/sync_committee.rs::tests` | `Err` paths the valid-only fixtures never produce: unservable signature periods, next-committee learning guard |
 | Update validation guards | `consensus/processor.rs::tests` | `Err` paths the valid-only fixtures never produce: minority participation, signature-slot ordering |
 | Public API | `tests/light_client_sync.rs` | Full replays through the public `LightClient`; `UpdateOutcome` contract |
-| Supermajority threshold | `types/consensus/committee.rs::tests` | Exact 2/3 participation boundary |
+| Supermajority threshold | `types/consensus/sync_committee.rs::tests` | Exact 2/3 participation boundary |
 | ChainSpec | `chain_spec/tests.rs` | `ChainSpecConfig` validation `Err` paths (the custom-config contract); `timestamp_to_slot` (wall-clock path the replays never touch) |
 
 ### Spec-case coverage

--- a/src/consensus/processor.rs
+++ b/src/consensus/processor.rs
@@ -1,7 +1,9 @@
 use crate::chain_spec::ChainSpec;
 use crate::consensus::merkle::{verify_light_client_header, verify_merkle_proof};
 use crate::consensus::store::LightClientStore;
-use crate::consensus::sync_committee;
+use crate::consensus::sync_committee::{
+    learn_next_sync_committee, should_rotate, verify_update_signature,
+};
 use crate::error::{Error, Result};
 use crate::types::consensus::{
     BeaconBlockHeader, LightClientHeader, LightClientUpdate, SyncCommittee,
@@ -60,22 +62,15 @@ impl LightClientProcessor {
     ) -> Result<UpdateChanges> {
         self.validate_light_client_update(&update, current_slot)?;
 
-        self.verify_update_signature(&update)?;
-
         self.apply_light_client_update(update)
     }
 
-    /// Validate basic update properties: fail fast principle
     fn validate_light_client_update(
         &self,
         update: &LightClientUpdate,
         current_slot: Slot,
     ) -> Result<()> {
-        if update.signature_slot <= update.attested_header.slot() {
-            return Err(Error::InvalidInput(
-                "Signature slot must be after attested header slot".to_string(),
-            ));
-        }
+        // Verify sync committee has sufficient participants
         if !update
             .sync_aggregate
             .has_supermajority(&self.store.current_sync_committee)
@@ -85,9 +80,19 @@ impl LightClientProcessor {
             ));
         }
 
+        // Verfiy update doesn't skip a sync committee period
+        //
+        // TODO: Make sure `verify_light_client_header` code block implements same functionality as spec's `is_valid_light_client_header`
         verify_light_client_header(&update.attested_header)?;
         if let Some(ref finalized) = update.finalized {
             verify_light_client_header(&finalized.header)?;
+        }
+
+        // TODO: Consolidate slot comparison conditions to one line (#132)
+        if update.signature_slot <= update.attested_header.slot() {
+            return Err(Error::InvalidInput(
+                "Signature slot must be after attested header slot".to_string(),
+            ));
         }
 
         if update.signature_slot > current_slot {
@@ -96,38 +101,14 @@ impl LightClientProcessor {
             ));
         }
 
-        Ok(())
-    }
-
-    fn verify_update_signature(&self, update: &LightClientUpdate) -> Result<()> {
-        let attested_header_root = update.attested_header.beacon().hash_tree_root();
-
-        // Look up the committee for the signature slot from the store
-        let committee = sync_committee::committee_for_signature_slot(
-            update.signature_slot,
+        verify_update_signature(
+            update,
             self.store.finalized_header.slot(),
             &self.store.current_sync_committee,
             self.store.next_sync_committee.as_ref(),
             &self.chain_spec,
-        )?;
-
-        let is_valid = sync_committee::verify_sync_aggregate(
-            committee,
-            update.signature_slot,
-            attested_header_root,
-            &update.sync_aggregate.sync_committee_bits,
-            &update.sync_aggregate.sync_committee_signature,
             self.store.genesis_validators_root,
-            &self.chain_spec,
-        )?;
-
-        if !is_valid {
-            return Err(Error::InvalidInput(
-                "Invalid sync committee signature".to_string(),
-            ));
-        }
-
-        Ok(())
+        )
     }
 
     fn apply_light_client_update(&mut self, update: LightClientUpdate) -> Result<UpdateChanges> {
@@ -151,7 +132,7 @@ impl LightClientProcessor {
                 changes.finalized_updated = true;
             }
 
-            if sync_committee::should_rotate(
+            if should_rotate(
                 finalized.header.slot(),
                 store_period,
                 self.store.next_sync_committee.is_some(),
@@ -168,7 +149,7 @@ impl LightClientProcessor {
 
         // Learn next AFTER the finalized-header update + rotation, using the now-updated finalized period (see consensus/README data flow).
         let finalized_period = self.store.finalized_sync_committee_period(&self.chain_spec);
-        if let Some(verified) = sync_committee::learn_next_sync_committee(
+        if let Some(verified) = learn_next_sync_committee(
             &update,
             finalized_period,
             self.store.next_sync_committee.is_some(),

--- a/src/consensus/store.rs
+++ b/src/consensus/store.rs
@@ -28,6 +28,8 @@ impl LightClientStore {
     }
 
     /// This is the canonical "store period" per consensus-specs.
+    //
+    // TODO: is this function needed?
     pub(crate) fn finalized_sync_committee_period(&self, spec: &ChainSpec) -> u64 {
         spec.slot_to_sync_committee_period(self.finalized_header.slot())
     }

--- a/src/consensus/sync_committee.rs
+++ b/src/consensus/sync_committee.rs
@@ -9,7 +9,43 @@ use tree_hash_derive::TreeHash;
 
 pub(crate) const DOMAIN_SYNC_COMMITTEE: [u8; 4] = [7, 0, 0, 0];
 
-pub(crate) fn committee_for_signature_slot<'a>(
+pub(crate) fn verify_update_signature(
+    update: &LightClientUpdate,
+    store_finalized_slot: Slot,
+    current_committee: &SyncCommittee,
+    next_committee: Option<&SyncCommittee>,
+    chain_spec: &ChainSpec,
+    genesis_validators_root: Root,
+) -> Result<()> {
+    let attested_header_root = update.attested_header.beacon().hash_tree_root();
+
+    let committee = committee_for_signature_slot(
+        update.signature_slot,
+        store_finalized_slot,
+        current_committee,
+        next_committee,
+        chain_spec,
+    )?;
+
+    let is_valid = verify_sync_aggregate(
+        committee,
+        update.signature_slot,
+        attested_header_root,
+        &update.sync_aggregate.sync_committee_bits,
+        &update.sync_aggregate.sync_committee_signature,
+        genesis_validators_root,
+        chain_spec,
+    )?;
+
+    if !is_valid {
+        return Err(Error::InvalidInput(
+            "Invalid sync committee signature".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+fn committee_for_signature_slot<'a>(
     signature_slot: Slot,
     store_finalized_slot: Slot,
     current_committee: &'a SyncCommittee,
@@ -32,7 +68,8 @@ pub(crate) fn committee_for_signature_slot<'a>(
     }
 }
 
-pub(crate) fn verify_sync_aggregate(
+// TODO: Just pass in the SyncAggregate.  No need to decompose in the signature
+fn verify_sync_aggregate(
     committee: &SyncCommittee,
     signature_slot: Slot,
     attested_header_root: Root,
@@ -100,7 +137,7 @@ pub(crate) fn learn_next_sync_committee(
     Ok(Some(next.committee.clone()))
 }
 
-pub(crate) fn compute_sync_committee_domain_for_signature_slot(
+fn compute_sync_committee_domain_for_signature_slot(
     signature_slot: Slot,
     genesis_validators_root: Root,
     chain_spec: &ChainSpec,

--- a/src/types/consensus.rs
+++ b/src/types/consensus.rs
@@ -1,7 +1,7 @@
-mod committee;
 mod headers;
 mod messages;
+mod sync_committee;
 
-pub use committee::*;
 pub use headers::*;
 pub use messages::*;
+pub use sync_committee::*;

--- a/src/types/consensus/sync_committee.rs
+++ b/src/types/consensus/sync_committee.rs
@@ -126,6 +126,7 @@ impl SyncAggregate {
         }
     }
 
+    // TODO: Is this wrapper needed?
     pub(crate) fn has_supermajority(&self, sync_committee: &SyncCommittee) -> bool {
         sync_committee.has_supermajority_participation(self.sync_committee_bits.as_ref())
     }


### PR DESCRIPTION
Groundwork for #128 (validate/apply factoring per the spec):

- **Fold**: `validate_light_client_update` now ends with the signature check, so the spec name carries the spec's meaning — validate does all rejection, apply will become pure mutation. Cheap checks still run before BLS.
- **Move**: `verify_update_signature` becomes a free function in `sync_committee.rs` taking explicit store fields (`&SyncCommittee`, `Option<&SyncCommittee>`, slots, roots), matching the module's other free functions and keeping the signature an honest dependency claim.
- **Rename**: `types/consensus/committee.rs` → `types/consensus/sync_committee.rs` to match the consensus module naming.
- Consensus README data flow updated to the two-step shape.
- Slot-ordering consolidation (spec's chained assert, incl. the missing `attested >= finalized` link) split out as #132.

The unconditional proof verification itself (both merkle proofs → validate) lands in a follow-up on #128.

Tests: `cargo test --features test-utils` all green (32 unit + 18 integration + doc-test); `cargo clippy --all-targets --features test-utils -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)